### PR TITLE
default to min-rounds=1

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ Benchpress itself requires no installation.  However running it requires the too
 To run the benchmarks in the default configuration from inside the environment in which you want to perform the tests run:
 
 ```bash
-python -m pytest --benchmark-min-rounds=1 benchpress/*_gym
+python -m pytest benchpress/*_gym
 ```
-where `*` is one of the frameworks that you want to test, and which matches the environment you are in.  Here `--benchmark-min-rounds=1`sets the minimum number of repeated trials to 1, which will save a great deal of time
+where `*` is one of the frameworks that you want to test, and which matches the environment you are in.
 
 To run the benchmarks and save to JSON one can do:
 
 ```bash
-python -m pytest --benchmark-min-rounds=1 --benchmark-save=SAVED_NAME  benchpress/*_gym
+python -m pytest --benchmark-save=SAVED_NAME  benchpress/*_gym
 ```
 which will save the file to the CWD in the `.benchmarks` folder
 

--- a/benchpress/pytest.ini
+++ b/benchpress/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
-addopts = -v -rs -p no:warnings
+addopts = -v -rs -p no:warnings --benchmark-min-rounds=1
+


### PR DESCRIPTION
Because the tests take so long, it is important to only do one round as the minimum (as opposed to the default of 5).  This codes that in the `pytest.ini` file