### PR TITLE
add all-to-all flexible backend

### DIFF
--- a/benchpress/bqskit_gym/abstract_transpile/test_qasmbench.py
+++ b/benchpress/bqskit_gym/abstract_transpile/test_qasmbench.py
@@ -24,7 +24,7 @@ from benchpress.workouts.abstract_transpile.qasmbench import (
     LARGE_NAMES,
 )
 #BACKEND = Configuration.backend()
-OPTIMIZATION_LEVEL = Configuration.options["tket"]["optimization_level"]
+OPTIMIZATION_LEVEL = Configuration.options["bqskit"]["optimization_level"]
 
 
 @benchpress_test_validation

--- a/benchpress/bqskit_gym/utils/bqskit_backend_utils.py
+++ b/benchpress/bqskit_gym/utils/bqskit_backend_utils.py
@@ -77,7 +77,10 @@ def _get_bqskit_machine_model(backend):
     gate_set = _basis_gate_str_to_bqskit_gate(basis_gates=basis_gates)
     if "ecr" in basis_gates:
         gate_set.add(ECRGate())
-    coupling_map = list({tuple(sorted(e)) for e in config.coupling_map})
+    if config.coupling_map:
+        coupling_map = list({tuple(sorted(e)) for e in config.coupling_map})
+    else:
+        coupling_map = None
     return MachineModel(num_qudits, coupling_map, gate_set)  # type: ignore
 
 

--- a/benchpress/utilities/backends/flexible_backend.py
+++ b/benchpress/utilities/backends/flexible_backend.py
@@ -35,7 +35,7 @@ class FlexibleBackend(GenericBackendV2):
             min_qubits (int): Minimum desired number of qubits
             layout (str): Target qubit topology.  Options are
                           'heavy-hex', 'linear', 'square', 'torus',
-                          or 'tree'
+                          'tree', or 'all-to-all'
             basis_gates (list): Supported basis gates.  If none
                                 supplied, defaults to the global
                                 default set
@@ -78,18 +78,23 @@ class FlexibleBackend(GenericBackendV2):
             cmap = CouplingMap(torus_coupling_map(min_qubits))
             num_qubits = cmap.size()
 
+        elif layout == 'all-to-all':
+            cmap = None
+            num_qubits = min_qubits
+
         else:
             raise ValueError(f"Invalid layout ({layout})")
 
         self._layout = layout
-        cmap.make_symmetric()
+        if cmap:
+            cmap.make_symmetric()
 
         self._configuration = QasmBackendConfiguration(
             backend_name=f"FlexibleBackend-{layout}",
             backend_version="1.0.0",
             basis_gates=self._basis_gates,
             conditional=False,
-            coupling_map=list(cmap),
+            coupling_map=list(cmap) if cmap else cmap,
             gates=None,
             local=True,
             max_shots=int(1e5),

--- a/default.conf
+++ b/default.conf
@@ -1,11 +1,11 @@
 [general]
 basis_gates = ['id', 'sx', 'x', 'rz', 'cz']
 backend_name = 'fake_torino'
-abstract_topologies = ['heavy-hex', 'square', 'linear']
+abstract_topologies = ['all-to-all', 'square', 'heavy-hex', 'linear']
 
 [bqskit]
 optimization_level = 1 # Setting this higher will lead to dramatically longer runtimes
-max_synthesis_size = 3
+max_synthesis_size = 3 # Currently do not use this setting
 
 [braket]
 


### PR DESCRIPTION
Adds an all-to-all `FlexibleBackend`.  This is nice to see what the output looks like with no routing.  This can be used to compare things like depth and gate counts in absence of added gates for routing.


Also took the opportunity to fix the setting of bqskit optimization in abstract transpile due to a copy-paste error on my part.