### PR TITLE
Record input circuit number of qubits in qasm tests

### DIFF
--- a/benchpress/bqskit_gym/utils/io.py
+++ b/benchpress/bqskit_gym/utils/io.py
@@ -27,4 +27,5 @@ def bqskit_qasm_loader(qasm_file, benchmark):
     circuit = Circuit.from_file(qasm_file)
     stop = perf_counter()
     benchmark.extra_info["qasm_load_time"] = stop - start
+    benchmark.extra_info["input_num_qubits"] = circuit.num_qudits
     return circuit

--- a/benchpress/braket_gym/utils/io.py
+++ b/benchpress/braket_gym/utils/io.py
@@ -31,4 +31,5 @@ def braket_qasm_loader(qasm_file, benchmark):
     circuit = Circuit.from_ir(data)
     stop = perf_counter()
     benchmark.extra_info["qasm_load_time"] = stop - start
+    benchmark.extra_info["input_num_qubits"] = circuit.qubit_count
     return circuit

--- a/benchpress/cirq_gym/utils/io.py
+++ b/benchpress/cirq_gym/utils/io.py
@@ -10,6 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 from time import perf_counter
+import cirq
 from cirq.contrib.qasm_import import circuit_from_qasm
 
 
@@ -27,4 +28,5 @@ def cirq_qasm_loader(qasm_file, benchmark):
     circuit = circuit_from_qasm(qasm_file)
     stop = perf_counter()
     benchmark.extra_info["qasm_load_time"] = stop - start
+    benchmark.extra_info["input_num_qubits"] = cirq.num_qubits(circuit)
     return circuit

--- a/benchpress/qiskit_gym/utils/io.py
+++ b/benchpress/qiskit_gym/utils/io.py
@@ -18,4 +18,5 @@ def qiskit_qasm_loader(qasm_file, benchmark):
     circuit = QuantumCircuit.from_qasm_file(qasm_file)
     stop = perf_counter()
     benchmark.extra_info["qasm_load_time"] = stop - start
+    benchmark.extra_info["input_num_qubits"] = circuit.num_qubits
     return circuit

--- a/benchpress/staq_gym/abstract_transpile/test_qasmbench.py
+++ b/benchpress/staq_gym/abstract_transpile/test_qasmbench.py
@@ -6,6 +6,7 @@ import pytest
 from qiskit import QuantumCircuit
 
 from benchpress.config import Configuration
+from benchpress.utilities.io import qasm_circuit_loader
 from benchpress.staq_gym.utils.staq_backend_utils import StaqFlexibleBackend
 from benchpress.workouts.abstract_transpile import (
     WorkoutAbstractQasmBenchLarge,
@@ -74,7 +75,7 @@ class TestWorkoutAbstractQasmBenchSmall(WorkoutAbstractQasmBenchSmall):
     @pytest.mark.parametrize("circ_and_topo", SMALL_CIRC_TOPO, ids=SMALL_NAMES)
     def test_QASMBench_small(self, benchmark, circ_and_topo, staq_device):
         input_qasm_file = circ_and_topo[0]
-        circuit = QuantumCircuit.from_qasm_file(input_qasm_file)
+        circuit = qasm_circuit_loader(input_qasm_file, benchmark)
         backend = StaqFlexibleBackend(
             circuit.num_qubits, circ_and_topo[1]
         ).get_staq_flexible_backend()
@@ -102,7 +103,7 @@ class TestWorkoutAbstractQasmBenchMedium(WorkoutAbstractQasmBenchMedium):
     @pytest.mark.parametrize("circ_and_topo", MEDIUM_CIRC_TOPO, ids=MEDIUM_NAMES)
     def test_QASMBench_medium(self, benchmark, circ_and_topo, staq_device):
         input_qasm_file = circ_and_topo[0]
-        circuit = QuantumCircuit.from_qasm_file(input_qasm_file)
+        circuit = qasm_circuit_loader(input_qasm_file, benchmark)
         backend = StaqFlexibleBackend(
             circuit.num_qubits, circ_and_topo[1]
         ).get_staq_flexible_backend()
@@ -130,7 +131,7 @@ class TestWorkoutAbstractQasmBenchLarge(WorkoutAbstractQasmBenchLarge):
     @pytest.mark.parametrize("circ_and_topo", LARGE_CIRC_TOPO_MARKED, ids=LARGE_NAMES)
     def test_QASMBench_large(self, benchmark, circ_and_topo, staq_device):
         input_qasm_file = circ_and_topo[0]
-        circuit = QuantumCircuit.from_qasm_file(input_qasm_file)
+        circuit = qasm_circuit_loader(input_qasm_file, benchmark)
         backend = StaqFlexibleBackend(
             circuit.num_qubits, circ_and_topo[1]
         ).get_staq_flexible_backend()

--- a/benchpress/staq_gym/device_transpile/test_feynman.py
+++ b/benchpress/staq_gym/device_transpile/test_feynman.py
@@ -18,6 +18,7 @@ import pytest
 from qiskit import QuantumCircuit
 
 from benchpress.config import Configuration
+from benchpress.utilities.io import qasm_circuit_loader
 from benchpress.workouts.device_transpile import WorkoutDeviceFeynman
 from benchpress.workouts.validation import benchpress_test_validation
 
@@ -71,7 +72,7 @@ class TestWorkoutDeviceFeynman(WorkoutDeviceFeynman):
         num_qubits = len(dev["qubits"])
         input_qasm_file = f"{Configuration.get_qasm_dir('feynman')}{filename}"
 
-        circuit = QuantumCircuit.from_qasm_file(input_qasm_file)
+        circuit = qasm_circuit_loader(input_qasm_file, benchmark)
         if circuit.num_qubits > num_qubits:
             pytest.skip("Circuit too large for given backend.")
 

--- a/benchpress/tket_gym/utils/io.py
+++ b/benchpress/tket_gym/utils/io.py
@@ -27,4 +27,5 @@ def tket_qasm_loader(qasm_file, benchmark):
     circuit = circuit_from_qasm(qasm_file)
     stop = perf_counter()
     benchmark.extra_info["qasm_load_time"] = stop - start
+    benchmark.extra_info["input_num_qubits"] = circuit.n_qubits
     return circuit

--- a/benchpress/utilities/io/qasm_loader.py
+++ b/benchpress/utilities/io/qasm_loader.py
@@ -24,7 +24,7 @@ def qasm_circuit_loader(qasm_file, benchmark):
         The circuit instance for the corresponding SDK
     """
     gym_name = Configuration.gym_name
-    if gym_name in ["qiskit", "qiskit-transpiler-service"]:
+    if gym_name in ["qiskit", "qiskit-transpiler-service", "staq"]:
         from benchpress.qiskit_gym.utils.io import qiskit_qasm_loader
 
         circuit = qiskit_qasm_loader(qasm_file, benchmark)


### PR DESCRIPTION
This PR records the number of qubits of the input circuits from all QASM file tests. This is nice so that we can think about sorting things based on this value, along with others.  Should also perhaps consider the input depth and or number and type of operations.