### PR TITLE
Cleanup handling of all-to-all connectivity in Qiskit validation

### DIFF
--- a/benchpress/qiskit_gym/utils/validation.py
+++ b/benchpress/qiskit_gym/utils/validation.py
@@ -27,10 +27,12 @@ def qiskit_circuit_validation(circuit, backend):
     if diff_set:
         raise Exception(f'Circuit has gates outside backend basis set {diff_set}')
 
-    edges = set(backend.coupling_map.get_edges())
-    for gate in circuit.get_instructions(backend.two_q_gate_type):
-        _edge = (circuit.find_bit(gate.qubits[0]).index,
-                circuit.find_bit(gate.qubits[1]).index)
-        if _edge not in edges:
-            raise Exception(f'2Q gate edge {_edge} not in backend topology')
+    cmap = backend.coupling_map
+    if cmap.graph.num_edges() < cmap.graph.num_nodes() * (cmap.graph.num_nodes()-1):
+        edges = set(cmap.get_edges())
+        for gate in circuit.get_instructions(backend.two_q_gate_type):
+            _edge = (circuit.find_bit(gate.qubits[0]).index,
+                    circuit.find_bit(gate.qubits[1]).index)
+            if _edge not in edges:
+                raise Exception(f'2Q gate edge {_edge} not in backend topology')
     return True


### PR DESCRIPTION
`None` is not used any more, so use another check rather than just dump edges