### PR TITLE
Add additional metric information to output files

### DIFF
--- a/benchpress/bqskit_gym/abstract_transpile/test_qasmbench.py
+++ b/benchpress/bqskit_gym/abstract_transpile/test_qasmbench.py
@@ -15,7 +15,7 @@ import pytest
 
 from bqskit import compile
 from bqskit.compiler import Compiler
-from benchpress.utilities.io import qasm_circuit_loader
+from benchpress.utilities.io import qasm_circuit_loader, output_circuit_properties
 from benchpress.utilities.validation import circuit_validator
 from benchpress.workouts.validation import benchpress_test_validation
 from benchpress.config import Configuration
@@ -44,7 +44,6 @@ class TestWorkoutAbstractQasmBenchSmall(WorkoutAbstractQasmBenchSmall):
     def test_QASMBench_small(self, benchmark, circ_and_topo):
         circuit = qasm_circuit_loader(circ_and_topo[0], benchmark)
         BACKEND = BqskitFlexibleBackend(circuit.num_qudits, circ_and_topo[1])
-        TWO_Q_GATE = BACKEND.two_q_gate_type
         compiler = Compiler()
 
         @benchmark
@@ -57,8 +56,7 @@ class TestWorkoutAbstractQasmBenchSmall(WorkoutAbstractQasmBenchSmall):
             )
             return new_circ
 
-        benchmark.extra_info["gate_count_2q"] = result.gate_counts[TWO_Q_GATE]
-        benchmark.extra_info["depth_2q"] = result.multi_qudit_depth
+        output_circuit_properties(result, BACKEND.two_q_gate_type, benchmark)
         assert circuit_validator(result, BACKEND)
 
 
@@ -68,7 +66,6 @@ class TestWorkoutAbstractQasmBenchMedium(WorkoutAbstractQasmBenchMedium):
     def test_QASMBench_medium(self, benchmark, circ_and_topo):
         circuit = qasm_circuit_loader(circ_and_topo[0], benchmark)
         BACKEND = BqskitFlexibleBackend(circuit.num_qudits, circ_and_topo[1])
-        TWO_Q_GATE = BACKEND.two_q_gate_type
         compiler = Compiler()
 
         @benchmark
@@ -81,8 +78,7 @@ class TestWorkoutAbstractQasmBenchMedium(WorkoutAbstractQasmBenchMedium):
             )
             return new_circ
 
-        benchmark.extra_info["gate_count_2q"] = result.gate_counts[TWO_Q_GATE]
-        benchmark.extra_info["depth_2q"] = result.multi_qudit_depth
+        output_circuit_properties(result, BACKEND.two_q_gate_type, benchmark)
         assert circuit_validator(result, BACKEND)
 
 
@@ -92,7 +88,6 @@ class TestWorkoutAbstractQasmBenchLarge(WorkoutAbstractQasmBenchLarge):
     def test_QASMBench_large(self, benchmark, circ_and_topo):
         circuit = qasm_circuit_loader(circ_and_topo[0], benchmark)
         BACKEND = BqskitFlexibleBackend(circuit.num_qudits, circ_and_topo[1])
-        TWO_Q_GATE = BACKEND.two_q_gate_type
         compiler = Compiler()
 
         @benchmark
@@ -105,6 +100,5 @@ class TestWorkoutAbstractQasmBenchLarge(WorkoutAbstractQasmBenchLarge):
             )
             return new_circ
 
-        benchmark.extra_info["gate_count_2q"] = result.gate_counts[TWO_Q_GATE]
-        benchmark.extra_info["depth_2q"] = result.multi_qudit_depth
+        output_circuit_properties(result, BACKEND.two_q_gate_type, benchmark)
         assert circuit_validator(result, BACKEND)

--- a/benchpress/bqskit_gym/device_transpile/test_feynman.py
+++ b/benchpress/bqskit_gym/device_transpile/test_feynman.py
@@ -15,7 +15,7 @@ import pytest
 from bqskit import compile
 from bqskit.compiler import Compiler
 
-from benchpress.utilities.io import qasm_circuit_loader
+from benchpress.utilities.io import qasm_circuit_loader, output_circuit_properties
 from benchpress.utilities.validation import circuit_validator
 from benchpress.config import Configuration
 from benchpress.workouts.validation import benchpress_test_validation
@@ -55,6 +55,5 @@ class TestWorkoutDeviceFeynman(WorkoutDeviceFeynman):
             )
             return new_circ
 
-        benchmark.extra_info["gate_count_2q"] = result.gate_counts[TWO_Q_GATE]
-        benchmark.extra_info["depth_2q"] = result.multi_qudit_depth
+        output_circuit_properties(result, TWO_Q_GATE, benchmark)
         assert circuit_validator(result, BACKEND)

--- a/benchpress/bqskit_gym/device_transpile/test_summit.py
+++ b/benchpress/bqskit_gym/device_transpile/test_summit.py
@@ -20,7 +20,7 @@ from benchpress.bqskit_gym.circuits import (
     trivial_bvlike_circuit,
 )
 from benchpress.config import Configuration
-from benchpress.utilities.io import qasm_circuit_loader
+from benchpress.utilities.io import qasm_circuit_loader, output_circuit_properties
 from benchpress.utilities.validation import circuit_validator
 from benchpress.workouts.validation import benchpress_test_validation
 from benchpress.workouts.device_transpile import WorkoutDeviceTranspile100Q
@@ -50,8 +50,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
             )
             return new_circ
 
-        benchmark.extra_info["gate_count_2q"] = result.gate_counts[TWO_Q_GATE]
-        benchmark.extra_info["depth_2q"] = result.multi_qudit_depth
+        output_circuit_properties(result, TWO_Q_GATE, benchmark)
         assert circuit_validator(result, BACKEND)
 
     def test_QV_100_transpile(self, benchmark):
@@ -70,8 +69,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
             )
             return new_circ
 
-        benchmark.extra_info["gate_count_2q"] = result.gate_counts[TWO_Q_GATE]
-        benchmark.extra_info["depth_2q"] = result.multi_qudit_depth
+        output_circuit_properties(result, TWO_Q_GATE, benchmark)
         assert circuit_validator(result, BACKEND)
 
     def test_circSU2_100_transpile(self, benchmark):
@@ -88,8 +86,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
             )
             return new_circ
 
-        benchmark.extra_info["gate_count_2q"] = result.gate_counts[TWO_Q_GATE]
-        benchmark.extra_info["depth_2q"] = result.multi_qudit_depth
+        output_circuit_properties(result, TWO_Q_GATE, benchmark)
         assert circuit_validator(result, BACKEND)
 
     def test_BV_100_transpile(self, benchmark):
@@ -106,8 +103,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
             )
             return new_circ
 
-        benchmark.extra_info["gate_count_2q"] = result.gate_counts[TWO_Q_GATE]
-        benchmark.extra_info["depth_2q"] = result.multi_qudit_depth
+        output_circuit_properties(result, TWO_Q_GATE, benchmark)
         assert circuit_validator(result, BACKEND)
 
     def test_square_heisenberg_100_transpile(self, benchmark):
@@ -128,8 +124,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
             )
             return new_circ
 
-        benchmark.extra_info["gate_count_2q"] = result.gate_counts[TWO_Q_GATE]
-        benchmark.extra_info["depth_2q"] = result.multi_qudit_depth
+        output_circuit_properties(result, TWO_Q_GATE, benchmark)
         assert circuit_validator(result, BACKEND)
 
     def test_QAOA_100_transpile(self, benchmark):
@@ -150,8 +145,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
             )
             return new_circ
 
-        benchmark.extra_info["gate_count_2q"] = result.gate_counts[TWO_Q_GATE]
-        benchmark.extra_info["depth_2q"] = result.multi_qudit_depth
+        output_circuit_properties(result, TWO_Q_GATE, benchmark)
         assert circuit_validator(result, BACKEND)
 
     def test_BVlike_simplification_transpile(self, benchmark):
@@ -171,6 +165,5 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
             )
             return new_circ
 
-        benchmark.extra_info["gate_count_2q"] = result.gate_counts[TWO_Q_GATE]
-        benchmark.extra_info["depth_2q"] = result.multi_qudit_depth
+        output_circuit_properties(result, TWO_Q_GATE, benchmark)
         assert circuit_validator(result, BACKEND)

--- a/benchpress/bqskit_gym/utils/io.py
+++ b/benchpress/bqskit_gym/utils/io.py
@@ -28,3 +28,15 @@ def bqskit_qasm_loader(qasm_file, benchmark):
     stop = perf_counter()
     benchmark.extra_info["qasm_load_time"] = stop - start
     return circuit
+
+
+def bqskit_output_circuit_properties(circuit, two_qubit_gate, benchmark):
+    ops = {}
+    for op in circuit.operations():
+        if op.gate.name in ops:
+            ops[op.gate.name] += 1
+        else:
+            ops[op.gate.name] = 1
+    benchmark.extra_info["circuit_operations"] = ops
+    benchmark.extra_info["gate_count_2q"] = circuit.gate_counts[two_qubit_gate]
+    benchmark.extra_info["depth_2q"] = circuit.multi_qudit_depth

--- a/benchpress/qiskit_gym/abstract_transpile/test_qasmbench.py
+++ b/benchpress/qiskit_gym/abstract_transpile/test_qasmbench.py
@@ -18,7 +18,7 @@ from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 from benchpress.workouts.validation import benchpress_test_validation
 from benchpress.config import Configuration
 from benchpress.utilities.backends import FlexibleBackend
-from benchpress.utilities.io import qasm_circuit_loader
+from benchpress.utilities.io import qasm_circuit_loader, output_circuit_properties
 from benchpress.utilities.validation import circuit_validator
 
 from benchpress.workouts.abstract_transpile import (
@@ -44,7 +44,6 @@ class TestWorkoutAbstractQasmBenchSmall(WorkoutAbstractQasmBenchSmall):
     def test_QASMBench_small(self, benchmark, circ_and_topo):
         circuit = qasm_circuit_loader(circ_and_topo[0], benchmark)
         backend = FlexibleBackend(circuit.num_qubits, circ_and_topo[1])
-        TWO_Q_GATE = backend.two_q_gate_type
         pm = generate_preset_pass_manager(
             optimization_level=OPTIMIZATION_LEVEL, backend=backend
         )
@@ -54,10 +53,7 @@ class TestWorkoutAbstractQasmBenchSmall(WorkoutAbstractQasmBenchSmall):
             trans_qc = pm.run(circuit)
             return trans_qc
 
-        benchmark.extra_info["gate_count_2q"] = result.count_ops().get(TWO_Q_GATE, 0)
-        benchmark.extra_info["depth_2q"] = result.depth(
-            filter_function=lambda x: x.operation.name == TWO_Q_GATE
-        )
+        output_circuit_properties(result, backend.two_q_gate_type, benchmark)
         assert circuit_validator(result, backend)
 
 
@@ -67,7 +63,6 @@ class TestWorkoutAbstractQasmBenchMedium(WorkoutAbstractQasmBenchMedium):
     def test_QASMBench_medium(self, benchmark, circ_and_topo):
         circuit = qasm_circuit_loader(circ_and_topo[0], benchmark)
         backend = FlexibleBackend(circuit.num_qubits, circ_and_topo[1])
-        TWO_Q_GATE = backend.two_q_gate_type
         pm = generate_preset_pass_manager(
             optimization_level=OPTIMIZATION_LEVEL, backend=backend
         )
@@ -77,10 +72,7 @@ class TestWorkoutAbstractQasmBenchMedium(WorkoutAbstractQasmBenchMedium):
             trans_qc = pm.run(circuit)
             return trans_qc
 
-        benchmark.extra_info["gate_count_2q"] = result.count_ops().get(TWO_Q_GATE, 0)
-        benchmark.extra_info["depth_2q"] = result.depth(
-            filter_function=lambda x: x.operation.name == TWO_Q_GATE
-        )
+        output_circuit_properties(result, backend.two_q_gate_type, benchmark)
         assert circuit_validator(result, backend)
 
 
@@ -90,7 +82,6 @@ class TestWorkoutAbstractQasmBenchLarge(WorkoutAbstractQasmBenchLarge):
     def test_QASMBench_large(self, benchmark, circ_and_topo):
         circuit = qasm_circuit_loader(circ_and_topo[0], benchmark)
         backend = FlexibleBackend(circuit.num_qubits, circ_and_topo[1])
-        TWO_Q_GATE = backend.two_q_gate_type
         pm = generate_preset_pass_manager(
             optimization_level=OPTIMIZATION_LEVEL, backend=backend
         )
@@ -100,8 +91,5 @@ class TestWorkoutAbstractQasmBenchLarge(WorkoutAbstractQasmBenchLarge):
             trans_qc = pm.run(circuit)
             return trans_qc
 
-        benchmark.extra_info["gate_count_2q"] = result.count_ops().get(TWO_Q_GATE, 0)
-        benchmark.extra_info["depth_2q"] = result.depth(
-            filter_function=lambda x: x.operation.name == TWO_Q_GATE
-        )
+        output_circuit_properties(result, backend.two_q_gate_type, benchmark)
         assert circuit_validator(result, backend)

--- a/benchpress/qiskit_gym/device_transpile/test_feynman.py
+++ b/benchpress/qiskit_gym/device_transpile/test_feynman.py
@@ -18,7 +18,7 @@ from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 from benchpress.config import Configuration
 from benchpress.workouts.validation import benchpress_test_validation
 from benchpress.workouts.device_transpile import WorkoutDeviceFeynman
-from benchpress.utilities.io import qasm_circuit_loader
+from benchpress.utilities.io import qasm_circuit_loader, output_circuit_properties
 from benchpress.utilities.validation import circuit_validator
 
 BACKEND = Configuration.backend()
@@ -49,8 +49,5 @@ class TestWorkoutDeviceFeynman(WorkoutDeviceFeynman):
             trans_qc = pm.run(circuit)
             return trans_qc
 
-        benchmark.extra_info["gate_count_2q"] = result.count_ops().get(TWO_Q_GATE, 0)
-        benchmark.extra_info["depth_2q"] = result.depth(
-            filter_function=lambda x: x.operation.name == TWO_Q_GATE
-        )
+        output_circuit_properties(result, TWO_Q_GATE, benchmark)
         assert circuit_validator(result, BACKEND)

--- a/benchpress/qiskit_gym/device_transpile/test_summit.py
+++ b/benchpress/qiskit_gym/device_transpile/test_summit.py
@@ -6,7 +6,7 @@ from qiskit.transpiler.passes import StarPreRouting
 from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 
 from benchpress.config import Configuration
-from benchpress.utilities.io import qasm_circuit_loader
+from benchpress.utilities.io import qasm_circuit_loader, output_circuit_properties
 from benchpress.utilities.validation import circuit_validator
 from benchpress.qiskit_gym.circuits import bv_all_ones
 
@@ -36,10 +36,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
             trans_qc = pm.run(circuit)
             return trans_qc
         
-        benchmark.extra_info["gate_count_2q"] = result.count_ops().get(TWO_Q_GATE, 0)
-        benchmark.extra_info["depth_2q"] = result.depth(
-            filter_function=lambda x: x.operation.name == TWO_Q_GATE
-        )
+        output_circuit_properties(result, TWO_Q_GATE, benchmark)
         assert circuit_validator(result, BACKEND)
 
     def test_QV_100_transpile(self, benchmark):
@@ -54,10 +51,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
             trans_qc = pm.run(circuit)
             return trans_qc
 
-        benchmark.extra_info["gate_count_2q"] = result.count_ops().get(TWO_Q_GATE, 0)
-        benchmark.extra_info["depth_2q"] = result.depth(
-            filter_function=lambda x: x.operation.name == TWO_Q_GATE
-        )
+        output_circuit_properties(result, TWO_Q_GATE, benchmark)
         assert circuit_validator(result, BACKEND)
 
     def test_circSU2_100_transpile(self, benchmark):
@@ -70,10 +64,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
             trans_qc = pm.run(circuit)
             return trans_qc
 
-        benchmark.extra_info["gate_count_2q"] = result.count_ops().get("cz", 0)
-        benchmark.extra_info["depth_2q"] = result.depth(
-            filter_function=lambda x: x.operation.name == TWO_Q_GATE
-        )
+        output_circuit_properties(result, TWO_Q_GATE, benchmark)
         assert circuit_validator(result, BACKEND)
 
     def test_BV_100_transpile(self, benchmark):
@@ -86,10 +77,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
             trans_qc = pm.run(circuit)
             return trans_qc
 
-        benchmark.extra_info["gate_count_2q"] = result.count_ops().get(TWO_Q_GATE, 0)
-        benchmark.extra_info["depth_2q"] = result.depth(
-            filter_function=lambda x: x.operation.name == TWO_Q_GATE
-        )
+        output_circuit_properties(result, TWO_Q_GATE, benchmark)
         assert circuit_validator(result, BACKEND)
 
     def test_square_heisenberg_100_transpile(self, benchmark):
@@ -106,10 +94,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
             trans_qc = pm.run(circuit)
             return trans_qc
 
-        benchmark.extra_info["gate_count_2q"] = result.count_ops().get(TWO_Q_GATE, 0)
-        benchmark.extra_info["depth_2q"] = result.depth(
-            filter_function=lambda x: x.operation.name == TWO_Q_GATE
-        )
+        output_circuit_properties(result, TWO_Q_GATE, benchmark)
         assert circuit_validator(result, BACKEND)
 
     def test_QAOA_100_transpile(self, benchmark):
@@ -125,10 +110,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
             trans_qc = pm.run(circuit)
             return trans_qc
 
-        benchmark.extra_info["gate_count_2q"] = result.count_ops().get(TWO_Q_GATE, 0)
-        benchmark.extra_info["depth_2q"] = result.depth(
-            filter_function=lambda x: x.operation.name == TWO_Q_GATE
-        )
+        output_circuit_properties(result, TWO_Q_GATE, benchmark)
         assert circuit_validator(result, BACKEND)
 
     def test_BVlike_simplification_transpile(self, benchmark):
@@ -143,8 +125,5 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
             trans_qc = pm.run(circuit)
             return trans_qc
 
-        benchmark.extra_info["gate_count_2q"] = result.count_ops().get(TWO_Q_GATE, 0)
-        benchmark.extra_info["depth_2q"] = result.depth(
-            filter_function=lambda x: x.operation.name == TWO_Q_GATE
-        )
+        output_circuit_properties(result, TWO_Q_GATE, benchmark)
         assert circuit_validator(result, BACKEND)

--- a/benchpress/qiskit_gym/utils/io.py
+++ b/benchpress/qiskit_gym/utils/io.py
@@ -19,3 +19,11 @@ def qiskit_qasm_loader(qasm_file, benchmark):
     stop = perf_counter()
     benchmark.extra_info["qasm_load_time"] = stop - start
     return circuit
+
+
+def qiskit_output_circuit_properties(circuit, two_qubit_gate, benchmark):
+    benchmark.extra_info["circuit_operations"] = circuit.count_ops()
+    benchmark.extra_info["gate_count_2q"] = circuit.count_ops().get(two_qubit_gate, 0)
+    benchmark.extra_info["depth_2q"] = circuit.depth(
+            filter_function=lambda x: x.operation.name == two_qubit_gate
+        )

--- a/benchpress/qiskit_transpiler_service_gym/abstract_transpile/test_qasmbench.py
+++ b/benchpress/qiskit_transpiler_service_gym/abstract_transpile/test_qasmbench.py
@@ -18,7 +18,7 @@ from qiskit_transpiler_service.transpiler_service import TranspilerService
 from benchpress.workouts.validation import benchpress_test_validation
 from benchpress.config import Configuration
 from benchpress.utilities.backends import FlexibleBackend
-from benchpress.utilities.io import qasm_circuit_loader
+from benchpress.utilities.io import qasm_circuit_loader, output_circuit_properties
 from benchpress.utilities.validation import circuit_validator
 from benchpress.workouts.abstract_transpile import (
     WorkoutAbstractQasmBenchSmall,
@@ -44,7 +44,6 @@ class TestWorkoutAbstractQasmBenchSmall(WorkoutAbstractQasmBenchSmall):
     def test_QASMBench_small(self, benchmark, circ_and_topo):
         circuit = qasm_circuit_loader(circ_and_topo[0], benchmark)
         BACKEND = FlexibleBackend(circuit.num_qubits, circ_and_topo[1])
-        TWO_Q_GATE = BACKEND.two_q_gate_type
         TRANS_SERVICE = TranspilerService(
             coupling_map=list(BACKEND.coupling_map.get_edges()),
             qiskit_transpile_options={"basis_gates": BACKEND.operation_names},
@@ -57,10 +56,7 @@ class TestWorkoutAbstractQasmBenchSmall(WorkoutAbstractQasmBenchSmall):
             trans_qc = TRANS_SERVICE.run(circuit)
             return trans_qc
 
-        benchmark.extra_info["gate_count_2q"] = result.count_ops().get(TWO_Q_GATE, 0)
-        benchmark.extra_info["depth_2q"] = result.depth(
-            filter_function=lambda x: x.operation.name == TWO_Q_GATE
-        )
+        output_circuit_properties(result, BACKEND.two_q_gate_type, benchmark)
         assert circuit_validator(result, BACKEND)
 
 
@@ -70,7 +66,6 @@ class TestWorkoutAbstractQasmBenchMedium(WorkoutAbstractQasmBenchMedium):
     def test_QASMBench_medium(self, benchmark, circ_and_topo):
         circuit = qasm_circuit_loader(circ_and_topo[0], benchmark)
         BACKEND = FlexibleBackend(circuit.num_qubits, circ_and_topo[1])
-        TWO_Q_GATE = BACKEND.two_q_gate_type
         TRANS_SERVICE = TranspilerService(
             coupling_map=list(BACKEND.coupling_map.get_edges()),
             qiskit_transpile_options={"basis_gates": BACKEND.operation_names},
@@ -83,10 +78,7 @@ class TestWorkoutAbstractQasmBenchMedium(WorkoutAbstractQasmBenchMedium):
             trans_qc = TRANS_SERVICE.run(circuit)
             return trans_qc
 
-        benchmark.extra_info["gate_count_2q"] = result.count_ops().get(TWO_Q_GATE, 0)
-        benchmark.extra_info["depth_2q"] = result.depth(
-            filter_function=lambda x: x.operation.name == TWO_Q_GATE
-        )
+        output_circuit_properties(result, BACKEND.two_q_gate_type, benchmark)
         assert circuit_validator(result, BACKEND)
 
 
@@ -96,7 +88,6 @@ class TestWorkoutAbstractQasmBenchLarge(WorkoutAbstractQasmBenchLarge):
     def test_QASMBench_large(self, benchmark, circ_and_topo):
         circuit = qasm_circuit_loader(circ_and_topo[0], benchmark)
         BACKEND = FlexibleBackend(circuit.num_qubits, circ_and_topo[1])
-        TWO_Q_GATE = BACKEND.two_q_gate_type
         TRANS_SERVICE = TranspilerService(
             coupling_map=list(BACKEND.coupling_map.get_edges()),
             qiskit_transpile_options={"basis_gates": BACKEND.operation_names},
@@ -109,8 +100,5 @@ class TestWorkoutAbstractQasmBenchLarge(WorkoutAbstractQasmBenchLarge):
             trans_qc = TRANS_SERVICE.run(circuit)
             return trans_qc
 
-        benchmark.extra_info["gate_count_2q"] = result.count_ops().get(TWO_Q_GATE, 0)
-        benchmark.extra_info["depth_2q"] = result.depth(
-            filter_function=lambda x: x.operation.name == TWO_Q_GATE
-        )
+        output_circuit_properties(result, BACKEND.two_q_gate_type, benchmark)
         assert circuit_validator(result, BACKEND)

--- a/benchpress/qiskit_transpiler_service_gym/device_transpile/test_feynman.py
+++ b/benchpress/qiskit_transpiler_service_gym/device_transpile/test_feynman.py
@@ -16,7 +16,7 @@ import pytest
 from qiskit_transpiler_service.transpiler_service import TranspilerService
 
 from benchpress.config import Configuration
-from benchpress.utilities.io import qasm_circuit_loader
+from benchpress.utilities.io import qasm_circuit_loader, output_circuit_properties
 from benchpress.utilities.validation import circuit_validator
 from benchpress.workouts.validation import benchpress_test_validation
 from benchpress.workouts.device_transpile import WorkoutDeviceFeynman
@@ -56,8 +56,5 @@ class TestWorkoutDeviceFeynman(WorkoutDeviceFeynman):
             trans_qc = TRANS_SERVICE.run(circuit)
             return trans_qc
 
-        benchmark.extra_info["gate_count_2q"] = result.count_ops().get(TWO_Q_GATE, 0)
-        benchmark.extra_info["depth_2q"] = result.depth(
-            filter_function=lambda x: x.operation.name == TWO_Q_GATE
-        )
+        output_circuit_properties(result, BACKEND.two_q_gate_type, benchmark)
         assert circuit_validator(result, BACKEND)

--- a/benchpress/qiskit_transpiler_service_gym/device_transpile/test_summit.py
+++ b/benchpress/qiskit_transpiler_service_gym/device_transpile/test_summit.py
@@ -17,7 +17,7 @@ from qiskit_transpiler_service.transpiler_service import TranspilerService
 
 from benchpress.config import Configuration
 from benchpress.qiskit_gym.circuits import bv_all_ones
-from benchpress.utilities.io import qasm_circuit_loader
+from benchpress.utilities.io import qasm_circuit_loader, output_circuit_properties
 from benchpress.utilities.validation import circuit_validator
 from benchpress.workouts.validation import benchpress_test_validation
 from benchpress.workouts.device_transpile import WorkoutDeviceTranspile100Q
@@ -48,10 +48,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
             trans_qc = TRANS_SERVICE.run(circuit)
             return trans_qc
 
-        benchmark.extra_info["gate_count_2q"] = result.count_ops().get(TWO_Q_GATE, 0)
-        benchmark.extra_info["depth_2q"] = result.depth(
-            filter_function=lambda x: x.operation.name == TWO_Q_GATE
-        )
+        output_circuit_properties(result, TWO_Q_GATE, benchmark)
         assert circuit_validator(result, BACKEND)
 
     def test_QV_100_transpile(self, benchmark):
@@ -65,10 +62,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
             trans_qc = TRANS_SERVICE.run(circuit)
             return trans_qc
 
-        benchmark.extra_info["gate_count_2q"] = result.count_ops().get(TWO_Q_GATE, 0)
-        benchmark.extra_info["depth_2q"] = result.depth(
-            filter_function=lambda x: x.operation.name == TWO_Q_GATE
-        )
+        output_circuit_properties(result, TWO_Q_GATE, benchmark)
         assert circuit_validator(result, BACKEND)
 
     def test_circSU2_100_transpile(self, benchmark):
@@ -80,10 +74,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
             trans_qc = TRANS_SERVICE.run(circuit)
             return trans_qc
 
-        benchmark.extra_info["gate_count_2q"] = result.count_ops().get(TWO_Q_GATE, 0)
-        benchmark.extra_info["depth_2q"] = result.depth(
-            filter_function=lambda x: x.operation.name == TWO_Q_GATE
-        )
+        output_circuit_properties(result, TWO_Q_GATE, benchmark)
         assert circuit_validator(result, BACKEND)
 
     def test_BV_100_transpile(self, benchmark):
@@ -95,10 +86,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
             trans_qc = TRANS_SERVICE.run(circuit)
             return trans_qc
 
-        benchmark.extra_info["gate_count_2q"] = result.count_ops().get(TWO_Q_GATE, 0)
-        benchmark.extra_info["depth_2q"] = result.depth(
-            filter_function=lambda x: x.operation.name == TWO_Q_GATE
-        )
+        output_circuit_properties(result, TWO_Q_GATE, benchmark)
         assert circuit_validator(result, BACKEND)
 
     def test_square_heisenberg_100_transpile(self, benchmark):
@@ -114,10 +102,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
             trans_qc = TRANS_SERVICE.run(circuit)
             return trans_qc
 
-        benchmark.extra_info["gate_count_2q"] = result.count_ops().get(TWO_Q_GATE, 0)
-        benchmark.extra_info["depth_2q"] = result.depth(
-            filter_function=lambda x: x.operation.name == TWO_Q_GATE
-        )
+        output_circuit_properties(result, TWO_Q_GATE, benchmark)
         assert circuit_validator(result, BACKEND)
 
     def test_QAOA_100_transpile(self, benchmark):
@@ -132,10 +117,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
             trans_qc = TRANS_SERVICE.run(circuit)
             return trans_qc
 
-        benchmark.extra_info["gate_count_2q"] = result.count_ops().get(TWO_Q_GATE, 0)
-        benchmark.extra_info["depth_2q"] = result.depth(
-            filter_function=lambda x: x.operation.name == TWO_Q_GATE
-        )
+        output_circuit_properties(result, TWO_Q_GATE, benchmark)
         assert circuit_validator(result, BACKEND)
 
     def test_BVlike_simplification_transpile(self, benchmark):
@@ -149,8 +131,5 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
             trans_qc = TRANS_SERVICE.run(circuit)
             return trans_qc
 
-        benchmark.extra_info["gate_count_2q"] = result.count_ops().get(TWO_Q_GATE, 0)
-        benchmark.extra_info["depth_2q"] = result.depth(
-            filter_function=lambda x: x.operation.name == TWO_Q_GATE
-        )
+        output_circuit_properties(result, TWO_Q_GATE, benchmark)
         assert circuit_validator(result, BACKEND)

--- a/benchpress/staq_gym/abstract_transpile/test_qasmbench.py
+++ b/benchpress/staq_gym/abstract_transpile/test_qasmbench.py
@@ -6,6 +6,7 @@ import pytest
 from qiskit import QuantumCircuit
 
 from benchpress.config import Configuration
+from benchpress.utilities.io import output_circuit_properties
 from benchpress.staq_gym.utils.staq_backend_utils import StaqFlexibleBackend
 from benchpress.workouts.abstract_transpile import (
     WorkoutAbstractQasmBenchLarge,
@@ -90,10 +91,7 @@ class TestWorkoutAbstractQasmBenchSmall(WorkoutAbstractQasmBenchSmall):
 
             return QuantumCircuit.from_qasm_str(out.stdout)
 
-        benchmark.extra_info["gate_count_2q"] = result.count_ops().get("cx", 0)
-        benchmark.extra_info["depth_2q"] = result.depth(
-            filter_function=lambda x: x.operation.name == "cx"
-        )
+        output_circuit_properties(result, 'cx', benchmark)
         assert result
 
 
@@ -118,10 +116,7 @@ class TestWorkoutAbstractQasmBenchMedium(WorkoutAbstractQasmBenchMedium):
 
             return QuantumCircuit.from_qasm_str(out.stdout)
 
-        benchmark.extra_info["gate_count_2q"] = result.count_ops().get("cx", 0)
-        benchmark.extra_info["depth_2q"] = result.depth(
-            filter_function=lambda x: x.operation.name == "cx"
-        )
+        output_circuit_properties(result, 'cx', benchmark)
         assert result
 
 
@@ -146,8 +141,5 @@ class TestWorkoutAbstractQasmBenchLarge(WorkoutAbstractQasmBenchLarge):
 
             return QuantumCircuit.from_qasm_str(out.stdout)
 
-        benchmark.extra_info["gate_count_2q"] = result.count_ops().get("cx", 0)
-        benchmark.extra_info["depth_2q"] = result.depth(
-            filter_function=lambda x: x.operation.name == "cx"
-        )
+        output_circuit_properties(result, 'cx', benchmark)
         assert result

--- a/benchpress/staq_gym/device_transpile/test_feynman.py
+++ b/benchpress/staq_gym/device_transpile/test_feynman.py
@@ -18,6 +18,7 @@ import pytest
 from qiskit import QuantumCircuit
 
 from benchpress.config import Configuration
+from benchpress.utilities.io import output_circuit_properties
 from benchpress.workouts.device_transpile import WorkoutDeviceFeynman
 from benchpress.workouts.validation import benchpress_test_validation
 
@@ -85,8 +86,5 @@ class TestWorkoutDeviceFeynman(WorkoutDeviceFeynman):
 
             return QuantumCircuit.from_qasm_str(out.stdout)
 
-        benchmark.extra_info["gate_count_2q"] = result.count_ops().get("cx", 0)
-        benchmark.extra_info["depth_2q"] = result.depth(
-            filter_function=lambda x: x.operation.name == "cx"
-        )
+        output_circuit_properties(result, 'cx', benchmark)
         assert result

--- a/benchpress/staq_gym/device_transpile/test_summit.py
+++ b/benchpress/staq_gym/device_transpile/test_summit.py
@@ -18,6 +18,7 @@ from qiskit import QuantumCircuit, qasm2
 from qiskit.circuit.library import EfficientSU2
 
 from benchpress.config import Configuration
+from benchpress.utilities.io import output_circuit_properties
 from benchpress.qiskit_gym.circuits import bv_all_ones, trivial_bvlike_circuit
 from benchpress.workouts.device_transpile import WorkoutDeviceTranspile100Q
 from benchpress.workouts.validation import benchpress_test_validation
@@ -77,10 +78,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
 
         # load output QASM as a QuantumCircuit to get statistics as
         # staq does not have built-in utilities for such
-        benchmark.extra_info["gate_count_2q"] = result.count_ops().get("cx", 0)
-        benchmark.extra_info["depth_2q"] = result.depth(
-            filter_function=lambda x: x.operation.name == "cx"
-        )
+        output_circuit_properties(result, 'cx', benchmark)
         assert result
 
     def test_QV_100_transpile(self, benchmark, staq_device):
@@ -101,10 +99,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
 
         # load output QASM as a QuantumCircuit to get statistics as
         # staq does not have built-in utilities for such
-        benchmark.extra_info["gate_count_2q"] = result.count_ops().get("cx", 0)
-        benchmark.extra_info["depth_2q"] = result.depth(
-            filter_function=lambda x: x.operation.name == "cx"
-        )
+        output_circuit_properties(result, 'cx', benchmark)
         assert result
 
     def test_circSU2_100_transpile(self, benchmark, tmp_path_factory, staq_device):
@@ -132,10 +127,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
 
             return QuantumCircuit.from_qasm_str(out.stdout)
 
-        benchmark.extra_info["gate_count_2q"] = result.count_ops().get("cx", 0)
-        benchmark.extra_info["depth_2q"] = result.depth(
-            filter_function=lambda x: x.operation.name == "cx"
-        )
+        output_circuit_properties(result, 'cx', benchmark)
         assert result
 
     def test_BV_100_transpile(self, benchmark, tmp_path_factory, staq_device):
@@ -157,10 +149,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
 
             return QuantumCircuit.from_qasm_str(out.stdout)
 
-        benchmark.extra_info["gate_count_2q"] = result.count_ops().get("cx", 0)
-        benchmark.extra_info["depth_2q"] = result.depth(
-            filter_function=lambda x: x.operation.name == "cx"
-        )
+        output_circuit_properties(result, 'cx', benchmark)
         assert result
 
     def test_square_heisenberg_100_transpile(self, benchmark, staq_device):
@@ -179,10 +168,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
 
             return QuantumCircuit.from_qasm_str(out.stdout)
 
-        benchmark.extra_info["gate_count_2q"] = result.count_ops().get("cx", 0)
-        benchmark.extra_info["depth_2q"] = result.depth(
-            filter_function=lambda x: x.operation.name == "cx"
-        )
+        output_circuit_properties(result, 'cx', benchmark)
         assert result
 
     def test_QAOA_100_transpile(self, benchmark, staq_device):
@@ -201,10 +187,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
 
             return QuantumCircuit.from_qasm_str(out.stdout)
 
-        benchmark.extra_info["gate_count_2q"] = result.count_ops().get("cx", 0)
-        benchmark.extra_info["depth_2q"] = result.depth(
-            filter_function=lambda x: x.operation.name == "cx"
-        )
+        output_circuit_properties(result, 'cx', benchmark)
         assert result
 
     def test_BVlike_simplification_transpile(
@@ -230,8 +213,5 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
 
             return QuantumCircuit.from_qasm_str(out.stdout)
 
-        benchmark.extra_info["gate_count_2q"] = result.count_ops().get("cx", 0)
-        benchmark.extra_info["depth_2q"] = result.depth(
-            filter_function=lambda x: x.operation.name == "cx"
-        )
+        output_circuit_properties(result, 'cx', benchmark)
         assert result

--- a/benchpress/staq_gym/utils/__init__.py
+++ b/benchpress/staq_gym/utils/__init__.py
@@ -1,0 +1,11 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.

--- a/benchpress/staq_gym/utils/io.py
+++ b/benchpress/staq_gym/utils/io.py
@@ -1,0 +1,19 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+
+def staq_output_circuit_properties(circuit, two_qubit_gate, benchmark):
+    benchmark.extra_info["circuit_operations"] = circuit.count_ops()
+    benchmark.extra_info["gate_count_2q"] = circuit.count_ops().get('cx', 0)
+    benchmark.extra_info["depth_2q"] = circuit.depth(
+            filter_function=lambda x: x.operation.name == 'cx'
+        )

--- a/benchpress/tket_gym/abstract_transpile/test_qasmbench.py
+++ b/benchpress/tket_gym/abstract_transpile/test_qasmbench.py
@@ -12,7 +12,7 @@
 """Test qasmbench against abstract backend topologies"""
 import pytest
 
-from benchpress.utilities.io import qasm_circuit_loader
+from benchpress.utilities.io import qasm_circuit_loader, output_circuit_properties
 from benchpress.utilities.validation import circuit_validator
 from benchpress.workouts.validation import benchpress_test_validation
 from benchpress.config import Configuration
@@ -41,7 +41,6 @@ class TestWorkoutAbstractQasmBenchSmall(WorkoutAbstractQasmBenchSmall):
     def test_QASMBench_small(self, benchmark, circ_and_topo):
         circuit = qasm_circuit_loader(circ_and_topo[0], benchmark)
         backend = TketFlexibleBackend(circuit.n_qubits, circ_and_topo[1])
-        TWO_Q_GATE = backend.two_q_gate_type
         pm = backend.default_compilation_pass(optimisation_level=OPTIMIZATION_LEVEL)
 
         @benchmark
@@ -51,8 +50,7 @@ class TestWorkoutAbstractQasmBenchSmall(WorkoutAbstractQasmBenchSmall):
             pm.apply(new_circ)
             return new_circ
 
-        benchmark.extra_info["gate_count_2q"] = result.n_gates_of_type(TWO_Q_GATE)
-        benchmark.extra_info["depth_2q"] = result.depth_by_type(TWO_Q_GATE)
+        output_circuit_properties(result, backend.two_q_gate_type, benchmark)
         assert circuit_validator(result, backend)
 
 
@@ -62,7 +60,6 @@ class TestWorkoutAbstractQasmBenchMedium(WorkoutAbstractQasmBenchMedium):
     def test_QASMBench_medium(self, benchmark, circ_and_topo):
         circuit = qasm_circuit_loader(circ_and_topo[0], benchmark)
         backend = TketFlexibleBackend(circuit.n_qubits, circ_and_topo[1])
-        TWO_Q_GATE = backend.two_q_gate_type
         pm = backend.default_compilation_pass(optimisation_level=OPTIMIZATION_LEVEL)
 
         @benchmark
@@ -72,8 +69,7 @@ class TestWorkoutAbstractQasmBenchMedium(WorkoutAbstractQasmBenchMedium):
             pm.apply(new_circ)
             return new_circ
 
-        benchmark.extra_info["gate_count_2q"] = result.n_gates_of_type(TWO_Q_GATE)
-        benchmark.extra_info["depth_2q"] = result.depth_by_type(TWO_Q_GATE)
+        output_circuit_properties(result, backend.two_q_gate_type, benchmark)
         assert circuit_validator(result, backend)
 
 
@@ -83,7 +79,6 @@ class TestWorkoutAbstractQasmBenchLarge(WorkoutAbstractQasmBenchLarge):
     def test_QASMBench_large(self, benchmark, circ_and_topo):
         circuit = qasm_circuit_loader(circ_and_topo[0], benchmark)
         backend = TketFlexibleBackend(circuit.n_qubits, circ_and_topo[1])
-        TWO_Q_GATE = backend.two_q_gate_type
         pm = backend.default_compilation_pass(optimisation_level=OPTIMIZATION_LEVEL)
 
         @benchmark
@@ -93,6 +88,5 @@ class TestWorkoutAbstractQasmBenchLarge(WorkoutAbstractQasmBenchLarge):
             pm.apply(new_circ)
             return new_circ
 
-        benchmark.extra_info["gate_count_2q"] = result.n_gates_of_type(TWO_Q_GATE)
-        benchmark.extra_info["depth_2q"] = result.depth_by_type(TWO_Q_GATE)
+        output_circuit_properties(result, backend.two_q_gate_type, benchmark)
         assert circuit_validator(result, backend)

--- a/benchpress/tket_gym/device_transpile/test_feynman.py
+++ b/benchpress/tket_gym/device_transpile/test_feynman.py
@@ -15,7 +15,7 @@ import os
 import pytest
 
 from benchpress.config import Configuration
-from benchpress.utilities.io import qasm_circuit_loader
+from benchpress.utilities.io import qasm_circuit_loader, output_circuit_properties
 from benchpress.utilities.validation import circuit_validator
 from benchpress.workouts.validation import benchpress_test_validation
 from benchpress.workouts.device_transpile import WorkoutDeviceFeynman
@@ -49,6 +49,5 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceFeynman):
             pm.apply(new_circ)
             return new_circ
 
-        benchmark.extra_info["gate_count_2q"] = result.n_gates_of_type(TWO_Q_GATE)
-        benchmark.extra_info["depth_2q"] = result.depth_by_type(TWO_Q_GATE)
+        output_circuit_properties(result, TWO_Q_GATE, benchmark)
         assert circuit_validator(result, BACKEND)

--- a/benchpress/tket_gym/device_transpile/test_summit.py
+++ b/benchpress/tket_gym/device_transpile/test_summit.py
@@ -13,7 +13,7 @@
 
 from benchpress.config import Configuration
 from benchpress.tket_gym.circuits import tket_bv_all_ones, tket_circSU2
-from benchpress.utilities.io import qasm_circuit_loader
+from benchpress.utilities.io import qasm_circuit_loader, output_circuit_properties
 from benchpress.utilities.validation import circuit_validator
 
 from benchpress.workouts.validation import benchpress_test_validation
@@ -41,8 +41,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
             pm.apply(new_circ)
             return new_circ
 
-        benchmark.extra_info["gate_count_2q"] = result.n_gates_of_type(TWO_Q_GATE)
-        benchmark.extra_info["depth_2q"] = result.depth_by_type(TWO_Q_GATE)
+        output_circuit_properties(result, TWO_Q_GATE, benchmark)
         assert circuit_validator(result, BACKEND)
 
     def test_QV_100_transpile(self, benchmark):
@@ -59,8 +58,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
             pm.apply(new_circ)
             return new_circ
 
-        benchmark.extra_info["gate_count_2q"] = result.n_gates_of_type(TWO_Q_GATE)
-        benchmark.extra_info["depth_2q"] = result.depth_by_type(TWO_Q_GATE)
+        output_circuit_properties(result, TWO_Q_GATE, benchmark)
         assert circuit_validator(result, BACKEND)
 
     def test_circSU2_100_transpile(self, benchmark):
@@ -75,8 +73,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
             pm.apply(new_circ)
             return new_circ
 
-        benchmark.extra_info["gate_count_2q"] = result.n_gates_of_type(TWO_Q_GATE)
-        benchmark.extra_info["depth_2q"] = result.depth_by_type(TWO_Q_GATE)
+        output_circuit_properties(result, TWO_Q_GATE, benchmark)
         assert circuit_validator(result, BACKEND)
 
     def test_BV_100_transpile(self, benchmark):
@@ -91,8 +88,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
             pm.apply(new_circ)
             return new_circ
 
-        benchmark.extra_info["gate_count_2q"] = result.n_gates_of_type(TWO_Q_GATE)
-        benchmark.extra_info["depth_2q"] = result.depth_by_type(TWO_Q_GATE)
+        output_circuit_properties(result, TWO_Q_GATE, benchmark)
         assert circuit_validator(result, BACKEND)
 
     def test_square_heisenberg_100_transpile(self, benchmark):
@@ -111,8 +107,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
             pm.apply(new_circ)
             return new_circ
 
-        benchmark.extra_info["gate_count_2q"] = result.n_gates_of_type(TWO_Q_GATE)
-        benchmark.extra_info["depth_2q"] = result.depth_by_type(TWO_Q_GATE)
+        output_circuit_properties(result, TWO_Q_GATE, benchmark)
         assert circuit_validator(result, BACKEND)
 
     def test_QAOA_100_transpile(self, benchmark):
@@ -130,8 +125,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
             pm.apply(new_circ)
             return new_circ
 
-        benchmark.extra_info["gate_count_2q"] = result.n_gates_of_type(TWO_Q_GATE)
-        benchmark.extra_info["depth_2q"] = result.depth_by_type(TWO_Q_GATE)
+        output_circuit_properties(result, TWO_Q_GATE, benchmark)
         assert circuit_validator(result, BACKEND)
 
     def test_BVlike_simplification_transpile(self, benchmark):
@@ -147,6 +141,5 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
             pm.apply(new_circ)
             return new_circ
 
-        benchmark.extra_info["gate_count_2q"] = result.n_gates_of_type(TWO_Q_GATE)
-        benchmark.extra_info["depth_2q"] = result.depth_by_type(TWO_Q_GATE)
+        output_circuit_properties(result, TWO_Q_GATE, benchmark)
         assert circuit_validator(result, BACKEND)

--- a/benchpress/tket_gym/utils/io.py
+++ b/benchpress/tket_gym/utils/io.py
@@ -36,7 +36,7 @@ def tket_output_circuit_properties(circuit, two_qubit_gate, benchmark):
         if command.op.type in ops:
             ops[command.op.type] += 1
         else:
-            ops[command.op.type] = 0
+            ops[command.op.type] = 1
     benchmark.extra_info["circuit_operations"] = ops
     benchmark.extra_info["gate_count_2q"] = circuit.n_gates_of_type(two_qubit_gate)
     benchmark.extra_info["depth_2q"] = circuit.depth_by_type(two_qubit_gate)

--- a/benchpress/tket_gym/utils/io.py
+++ b/benchpress/tket_gym/utils/io.py
@@ -28,3 +28,15 @@ def tket_qasm_loader(qasm_file, benchmark):
     stop = perf_counter()
     benchmark.extra_info["qasm_load_time"] = stop - start
     return circuit
+
+
+def tket_output_circuit_properties(circuit, two_qubit_gate, benchmark):
+    ops = {}
+    for command in circuit.get_commands():
+        if command.op.type in ops:
+            ops[command.op.type] += 1
+        else:
+            ops[command.op.type] = 0
+    benchmark.extra_info["circuit_operations"] = ops
+    benchmark.extra_info["gate_count_2q"] = circuit.n_gates_of_type(two_qubit_gate)
+    benchmark.extra_info["depth_2q"] = circuit.depth_by_type(two_qubit_gate)

--- a/benchpress/utilities/backends/flexible_backend.py
+++ b/benchpress/utilities/backends/flexible_backend.py
@@ -79,7 +79,7 @@ class FlexibleBackend(GenericBackendV2):
             num_qubits = cmap.size()
 
         elif layout == "all-to-all":
-            cmap = None
+            cmap = CouplingMap.from_full(min_qubits)
             num_qubits = min_qubits
 
         else:

--- a/benchpress/utilities/io/__init__.py
+++ b/benchpress/utilities/io/__init__.py
@@ -2,3 +2,4 @@
 
 from .qasmbench import get_qasmbench_circuits
 from .qasm_loader import qasm_circuit_loader
+from .circuit_output import output_circuit_properties

--- a/benchpress/utilities/io/circuit_output.py
+++ b/benchpress/utilities/io/circuit_output.py
@@ -1,0 +1,31 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""QASMbench utilities"""
+
+from benchpress.config import Configuration
+
+
+def output_circuit_properties(circuit, two_qubit_gate, benchmark):
+    """Return circuit statistics
+
+    circuit : Input quantum circuit
+    two_qubit_gate : Target two-qubit gate
+    benchmark (Benchmark): Benchmark class to record info to
+
+    """
+    gym_name = Configuration.gym_name
+    if gym_name in ["qiskit", "qiskit-transpiler-service"]:
+        from benchpress.qiskit_gym.utils.io import qiskit_output_circuit_properties
+        qiskit_output_circuit_properties(circuit, two_qubit_gate, benchmark)
+    else:
+        raise Exception(f'Unsupported gym name {gym_name}')
+

--- a/benchpress/utilities/io/circuit_output.py
+++ b/benchpress/utilities/io/circuit_output.py
@@ -26,6 +26,9 @@ def output_circuit_properties(circuit, two_qubit_gate, benchmark):
     if gym_name in ["qiskit", "qiskit-transpiler-service"]:
         from benchpress.qiskit_gym.utils.io import qiskit_output_circuit_properties
         qiskit_output_circuit_properties(circuit, two_qubit_gate, benchmark)
+    
+    elif gym_name == "tket":
+        from benchpress.tket_gym.utils.io import tket_output_circuit_properties
+        tket_output_circuit_properties(circuit, two_qubit_gate, benchmark)
     else:
         raise Exception(f'Unsupported gym name {gym_name}')
-

--- a/benchpress/utilities/io/circuit_output.py
+++ b/benchpress/utilities/io/circuit_output.py
@@ -30,5 +30,9 @@ def output_circuit_properties(circuit, two_qubit_gate, benchmark):
     elif gym_name == "tket":
         from benchpress.tket_gym.utils.io import tket_output_circuit_properties
         tket_output_circuit_properties(circuit, two_qubit_gate, benchmark)
+    
+    elif gym_name == "bqskit":
+        from benchpress.bqskit_gym.utils.io import bqskit_output_circuit_properties
+        bqskit_output_circuit_properties(circuit, two_qubit_gate, benchmark)
     else:
         raise Exception(f'Unsupported gym name {gym_name}')

--- a/benchpress/utilities/io/circuit_output.py
+++ b/benchpress/utilities/io/circuit_output.py
@@ -34,5 +34,9 @@ def output_circuit_properties(circuit, two_qubit_gate, benchmark):
     elif gym_name == "bqskit":
         from benchpress.bqskit_gym.utils.io import bqskit_output_circuit_properties
         bqskit_output_circuit_properties(circuit, two_qubit_gate, benchmark)
+
+    elif gym_name == "staq":
+        from benchpress.staq_gym.utils.io import staq_output_circuit_properties
+        staq_output_circuit_properties(circuit, two_qubit_gate, benchmark)
     else:
         raise Exception(f'Unsupported gym name {gym_name}')


### PR DESCRIPTION
This adds information as to the total number of operations in each SDK at the end of transpilation, equivalent to `QuantumCircuit.count_ops` in Qiskit.

This PR also cleans up a lot of duplicate code