### PR TITLE
Add count of each test status and total duration

### DIFF
--- a/benchpress/conftest.py
+++ b/benchpress/conftest.py
@@ -10,13 +10,25 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 # conftest.py
+import time
 import numpy
 import scipy
 
 
 def pytest_benchmark_update_json(config, benchmarks, output_json):
     """Adds custom sections to the pytest-benchmark report"""
+    reporter = config.pluginmanager.get_plugin('terminalreporter')
+
+    output_json["total_duration"] = time.time() - reporter._sessionstarttime
+
     output_json["env_info"] = {
         "numpy": str(numpy.__version__),
         "scipy": str(scipy.__version__),
+    }
+
+    output_json["test_status_counts"] = {
+        'passed': len(reporter.stats.get('passed', [])),
+        'failed': len(reporter.stats.get('failed', [])),
+        'xfailed': len(reporter.stats.get('xfailed', [])),
+        'skipped': len(reporter.stats.get('skipped', []))
     }


### PR DESCRIPTION
We weren't outputting the counts of each test status type to the output json file.  Also, we weren't collecting the total test suite duration as well.  These were printed to the terminal report, but this puts everything in one spot.