### PR TITLE
Add 89Q circSU2 test

### DIFF
--- a/benchpress/bqskit_gym/device_transpile/test_summit.py
+++ b/benchpress/bqskit_gym/device_transpile/test_summit.py
@@ -72,6 +72,23 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
         output_circuit_properties(result, TWO_Q_GATE, benchmark)
         assert circuit_validator(result, BACKEND)
 
+    def test_circSU2_89_transpile(self, benchmark):
+        """Compile 89Q circSU2 circuit against target backend"""
+        circuit = bqskit_circSU2(89, 3)
+
+        @benchmark
+        def result():
+            new_circ = compile(
+                circuit,
+                model=BACKEND,
+                optimization_level=OPTIMIZATION_LEVEL,
+                compiler=compiler,
+            )
+            return new_circ
+
+        output_circuit_properties(result, TWO_Q_GATE, benchmark)
+        assert circuit_validator(result, BACKEND)
+
     def test_circSU2_100_transpile(self, benchmark):
         """Compile 100Q circSU2 circuit against target backend"""
         circuit = bqskit_circSU2(100, 3)

--- a/benchpress/qiskit_gym/device_transpile/test_summit.py
+++ b/benchpress/qiskit_gym/device_transpile/test_summit.py
@@ -54,6 +54,20 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
         output_circuit_properties(result, TWO_Q_GATE, benchmark)
         assert circuit_validator(result, BACKEND)
 
+    def test_circSU2_89_transpile(self, benchmark):
+        """Compile 89Q circSU2 circuit against target backend"""
+        circuit = EfficientSU2(89, reps=3, entanglement="circular")
+        pm = generate_preset_pass_manager(OPTIMIZATION_LEVEL, BACKEND)
+
+        @benchmark
+        def result():
+            trans_qc = pm.run(circuit)
+            return trans_qc
+
+        output_circuit_properties(result, TWO_Q_GATE, benchmark)
+        assert circuit_validator(result, BACKEND)
+    
+    
     def test_circSU2_100_transpile(self, benchmark):
         """Compile 100Q circSU2 circuit against target backend"""
         circuit = EfficientSU2(100, reps=3, entanglement="circular")

--- a/benchpress/staq_gym/device_transpile/test_summit.py
+++ b/benchpress/staq_gym/device_transpile/test_summit.py
@@ -102,6 +102,34 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
         output_circuit_properties(result, 'cx', benchmark)
         assert result
 
+    def test_circSU2_89_transpile(self, benchmark, tmp_path_factory, staq_device):
+        """Compile 89Q circSU2 circuit against target backend"""
+        device = staq_device(backend=BACKEND)
+        circuit = EfficientSU2(89, reps=3, entanglement="circular")
+
+        # staq works on qasm files only & qasm files need bounded params
+        num_parameters = circuit.num_parameters
+        np.random.seed(0)
+        params = np.random.uniform(low=0.1, high=np.pi, size=num_parameters)
+        circuit.assign_parameters(parameters=params, inplace=True)
+
+        base_temp_dir = tmp_path_factory.getbasetemp()
+        input_qasm_file = base_temp_dir / "circ.qasm"
+        qasm2.dump(circuit, input_qasm_file)
+
+        @benchmark
+        def result():
+            out = subprocess.run(
+                RUN_ARGS_COMMON + ["-m", "--device", device, input_qasm_file],
+                capture_output=True,
+                text=True,
+            )
+
+            return QuantumCircuit.from_qasm_str(out.stdout)
+
+        output_circuit_properties(result, 'cx', benchmark)
+        assert result
+    
     def test_circSU2_100_transpile(self, benchmark, tmp_path_factory, staq_device):
         """Compile 100Q circSU2 circuit against target backend"""
         device = staq_device(backend=BACKEND)

--- a/benchpress/tket_gym/device_transpile/test_summit.py
+++ b/benchpress/tket_gym/device_transpile/test_summit.py
@@ -61,6 +61,21 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
         output_circuit_properties(result, TWO_Q_GATE, benchmark)
         assert circuit_validator(result, BACKEND)
 
+    def test_circSU2_89_transpile(self, benchmark):
+        """Compile 89Q circSU2 circuit against target backend"""
+        circuit = tket_circSU2(89, 3)
+        pm = BACKEND.default_compilation_pass(optimisation_level=OPTIMIZATION_LEVEL)
+
+        @benchmark
+        def result():
+            # Need to make a copy as the compilation is done in-place
+            new_circ = circuit.copy()
+            pm.apply(new_circ)
+            return new_circ
+
+        output_circuit_properties(result, TWO_Q_GATE, benchmark)
+        assert circuit_validator(result, BACKEND)
+    
     def test_circSU2_100_transpile(self, benchmark):
         """Compile 100Q circSU2 circuit against target backend"""
         circuit = tket_circSU2(100, 3)

--- a/benchpress/workouts/device_transpile/device_transpile_100Q.py
+++ b/benchpress/workouts/device_transpile/device_transpile_100Q.py
@@ -26,8 +26,13 @@ class WorkoutDeviceTranspile100Q:
         pass
 
     @pytest.mark.skip(reason="Not implimented")
+    def test_circSU2_89_transpile(self, benchmark):
+        """Transpile a 89Q SU2 circuit with circular entanglement against a target device"""
+        pass
+    
+    @pytest.mark.skip(reason="Not implimented")
     def test_circSU2_100_transpile(self, benchmark):
-        """Transpile a SU2 circuit with circular entanglement against a target device"""
+        """Transpile a 100Q SU2 circuit with circular entanglement against a target device"""
         pass
 
     @pytest.mark.skip(reason="Not implimented")


### PR DESCRIPTION
The 100Q circSU2 test exactly matches the heavy-hex topology we test against in the device transpile section.  Thus it is useful for finding if a SDKs routing capabilities can find that.  Here we add a 89Q version that does not fit on the topology, thus requiring swaps.  

closes #44 