### PR TITLE
Change Staq ABI skips to failures

### DIFF
--- a/benchpress/staq_gym/abstract_transpile/test_qasmbench.py
+++ b/benchpress/staq_gym/abstract_transpile/test_qasmbench.py
@@ -40,23 +40,6 @@ RUN_ARGS_COMMON = [
     "qasm",
 ]
 
-# `cc` and `qft` circuits throw 'stoi: out of range' error.
-# So, those tests will be marked as `skip`
-mark_large_tests = ("cc", "qft")
-reason = (
-    "libc++abi: terminating due to uncaught exception of type "
-    "std::out_of_range: stoi: out of range"
-)
-
-LARGE_CIRC_TOPO_MARKED = [
-    (
-        pytest.param(circ_and_topo, marks=pytest.mark.skip(reason=reason), id=name)
-        if name.startswith(mark_large_tests)
-        else circ_and_topo
-    )
-    for circ_and_topo, name in zip(LARGE_CIRC_TOPO, LARGE_NAMES)
-]
-
 
 @pytest.fixture(scope="session")
 def staq_device(tmp_path_factory):
@@ -122,7 +105,7 @@ class TestWorkoutAbstractQasmBenchMedium(WorkoutAbstractQasmBenchMedium):
 
 @benchpress_test_validation
 class TestWorkoutAbstractQasmBenchLarge(WorkoutAbstractQasmBenchLarge):
-    @pytest.mark.parametrize("circ_and_topo", LARGE_CIRC_TOPO_MARKED, ids=LARGE_NAMES)
+    @pytest.mark.parametrize("circ_and_topo", LARGE_CIRC_TOPO, ids=LARGE_NAMES)
     def test_QASMBench_large(self, benchmark, circ_and_topo, staq_device):
         input_qasm_file = circ_and_topo[0]
         circuit = qasm_circuit_loader(input_qasm_file, benchmark)

--- a/benchpress/staq_gym/device_transpile/test_summit.py
+++ b/benchpress/staq_gym/device_transpile/test_summit.py
@@ -56,10 +56,6 @@ def staq_device(tmp_path_factory):
 
 @benchpress_test_validation
 class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
-    @pytest.mark.skip(
-        reason="Error: libc++abi: terminating due to uncaught exception of type "
-        "std::out_of_range: stoi: out of range",
-    )
     def test_QFT_100_transpile(self, benchmark, staq_device):
         """Compile 100Q QFT circuit against target backend"""
         device = staq_device(backend=BACKEND)


### PR DESCRIPTION
This changes the Staq skips for ABI issues over to test failures.  The failures do not affect other tests and thus do not need to be marked as xfail.  This brings the tests status inline with the definitions in the readme.

closes #47 