### PR TITLE
Fix tket circuit properties output

### DIFF
--- a/benchpress/tket_gym/utils/io.py
+++ b/benchpress/tket_gym/utils/io.py
@@ -34,10 +34,11 @@ def tket_qasm_loader(qasm_file, benchmark):
 def tket_output_circuit_properties(circuit, two_qubit_gate, benchmark):
     ops = {}
     for command in circuit.get_commands():
-        if command.op.type in ops:
-            ops[command.op.type] += 1
+        cmd_name = command.op.type.name
+        if cmd_name in ops:
+            ops[cmd_name] += 1
         else:
-            ops[command.op.type] = 1
+            ops[cmd_name] = 1
     benchmark.extra_info["circuit_operations"] = ops
     benchmark.extra_info["gate_count_2q"] = circuit.n_gates_of_type(two_qubit_gate)
     benchmark.extra_info["depth_2q"] = circuit.depth_by_type(two_qubit_gate)


### PR DESCRIPTION
The output was using `Optype` which is not json serializable.  This gets the op name which is a string