### PR TITLE
Update tket maxwidth in construct

### DIFF
--- a/benchpress/tket_gym/construct/test_build.py
+++ b/benchpress/tket_gym/construct/test_build.py
@@ -140,7 +140,7 @@ class TestWorkoutCircuitConstruction(WorkoutCircuitConstruction):
         @benchmark
         def result():
             out = circuit_from_qasm(
-                Configuration.get_qasm_dir("bigint") + "bigint.qasm"
+                Configuration.get_qasm_dir("bigint") + "bigint.qasm", maxwidth=500
             )
             return out
 


### PR DESCRIPTION
The bigint test for Tket in the circuit construction tests needs `maxwidth` set