### PR TITLE
Set tket max creg size to 500

### DIFF
--- a/benchpress/tket_gym/utils/io.py
+++ b/benchpress/tket_gym/utils/io.py
@@ -12,6 +12,7 @@
 from time import perf_counter
 from pytket.qasm import circuit_from_qasm
 
+from benchpress.config import Configuration
 
 def tket_qasm_loader(qasm_file, benchmark):
     """Loads a QASM file and measures the import time
@@ -24,7 +25,7 @@ def tket_qasm_loader(qasm_file, benchmark):
         Circuit: A Tket circuit instance
     """
     start = perf_counter()
-    circuit = circuit_from_qasm(qasm_file)
+    circuit = circuit_from_qasm(qasm_file, maxwidth=Configuration.options["tket"]["maxwidth"])
     stop = perf_counter()
     benchmark.extra_info["qasm_load_time"] = stop - start
     benchmark.extra_info["input_num_qubits"] = circuit.n_qubits

--- a/default.conf
+++ b/default.conf
@@ -16,6 +16,7 @@ optimization_level = 2
 
 [tket]
 optimization_level = 2
+maxwidth = 500
 
 [staq]
 optimization_level = 2


### PR DESCRIPTION
Tket has a funny thing where they require an user to specific the max size of a QASM creg at import.  I have no idea why they do this, and not just parse at import but Tket will fail a bunch of tests if this is not set explicitly.  Here I set it in the `default.conf` to `500`, which is large enough for all the tests here.