### PR TITLE
Add circ89 test to transpiler service tests

### DIFF
--- a/benchpress/qiskit_transpiler_service_gym/device_transpile/test_summit.py
+++ b/benchpress/qiskit_transpiler_service_gym/device_transpile/test_summit.py
@@ -64,6 +64,18 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
 
         output_circuit_properties(result, TWO_Q_GATE, benchmark)
         assert circuit_validator(result, BACKEND)
+    
+    def test_circSU2_89_transpile(self, benchmark):
+        """Compile 89Q circSU2 circuit against target backend"""
+        circuit = EfficientSU2(89, reps=3, entanglement="circular")
+
+        @benchmark
+        def result():
+            trans_qc = TRANS_SERVICE.run(circuit)
+            return trans_qc
+
+        output_circuit_properties(result, TWO_Q_GATE, benchmark)
+        assert circuit_validator(result, BACKEND)
 
     def test_circSU2_100_transpile(self, benchmark):
         """Compile 100Q circSU2 circuit against target backend"""


### PR DESCRIPTION
The circ89 test was missing from the service tests.  This adds it