### PR TITLE
Remove `-c` (`--cnot-resynthesis`) flag from Staq and truncate OPTIMIZATION-LEVEL

### DIFF
--- a/benchpress/staq_gym/abstract_transpile/test_qasmbench.py
+++ b/benchpress/staq_gym/abstract_transpile/test_qasmbench.py
@@ -29,7 +29,7 @@ OPTIMIZATION_LEVEL = Configuration.options["staq"]["optimization_level"]
 # Truncating OPTIMIZATION_LEVEL to max 2
 # OPTIMIZATION_LEVEL=3 uses a `--cnot-resynthesis` flag
 # that removes qubit connectivity
-OPTIMIZATION_LEVEL = 2 if OPTIMIZATION_LEVEL > 2 else OPTIMIZATION_LEVEL
+OPTIMIZATION_LEVEL = min(2, OPTIMIZATION_LEVEL)
 
 LAYOUT = Configuration.options["staq"]["layout"]
 MAPPING = Configuration.options["staq"]["mapping"]

--- a/benchpress/staq_gym/abstract_transpile/test_qasmbench.py
+++ b/benchpress/staq_gym/abstract_transpile/test_qasmbench.py
@@ -26,13 +26,17 @@ from benchpress.workouts.validation import benchpress_test_validation
 
 OPTIMIZATION_LEVEL = Configuration.options["staq"]["optimization_level"]
 
+# Truncating OPTIMIZATION_LEVEL to max 2
+# OPTIMIZATION_LEVEL=3 uses a `--cnot-resynthesis` flag
+# that removes qubit connectivity
+OPTIMIZATION_LEVEL = 2 if OPTIMIZATION_LEVEL > 2 else OPTIMIZATION_LEVEL
+
 LAYOUT = Configuration.options["staq"]["layout"]
 MAPPING = Configuration.options["staq"]["mapping"]
 RUN_ARGS_COMMON = [
     "staq",
     "-S",
     f"-O{OPTIMIZATION_LEVEL}",
-    "-c",
     "-l",
     LAYOUT,
     "-M",

--- a/benchpress/staq_gym/device_transpile/test_feynman.py
+++ b/benchpress/staq_gym/device_transpile/test_feynman.py
@@ -27,11 +27,15 @@ LAYOUT = Configuration.options["staq"]["layout"]
 MAPPING = Configuration.options["staq"]["mapping"]
 OPTIMIZATION_LEVEL = Configuration.options["staq"]["optimization_level"]
 
+# Truncating OPTIMIZATION_LEVEL to max 2
+# OPTIMIZATION_LEVEL=3 uses a `--cnot-resynthesis` flag
+# that removes qubit connectivity
+OPTIMIZATION_LEVEL = 2 if OPTIMIZATION_LEVEL > 2 else OPTIMIZATION_LEVEL
+
 RUN_ARGS_COMMON = [
     "staq",
     "-S",
     f"-O{OPTIMIZATION_LEVEL}",
-    "-c",
     "-l",
     LAYOUT,
     "-M",

--- a/benchpress/staq_gym/device_transpile/test_feynman.py
+++ b/benchpress/staq_gym/device_transpile/test_feynman.py
@@ -35,7 +35,7 @@ OPTIMIZATION_LEVEL = Configuration.options["staq"]["optimization_level"]
 # Truncating OPTIMIZATION_LEVEL to max 2
 # OPTIMIZATION_LEVEL=3 uses a `--cnot-resynthesis` flag
 # that removes qubit connectivity
-OPTIMIZATION_LEVEL = 2 if OPTIMIZATION_LEVEL > 2 else OPTIMIZATION_LEVEL
+OPTIMIZATION_LEVEL = min(2, OPTIMIZATION_LEVEL)
 
 RUN_ARGS_COMMON = [
     "staq",

--- a/benchpress/staq_gym/device_transpile/test_summit.py
+++ b/benchpress/staq_gym/device_transpile/test_summit.py
@@ -28,11 +28,15 @@ LAYOUT = Configuration.options["staq"]["layout"]
 MAPPING = Configuration.options["staq"]["mapping"]
 OPTIMIZATION_LEVEL = Configuration.options["staq"]["optimization_level"]
 
+# Truncating OPTIMIZATION_LEVEL to max 2
+# OPTIMIZATION_LEVEL=3 uses a `--cnot-resynthesis` flag
+# that removes qubit connectivity
+OPTIMIZATION_LEVEL = 2 if OPTIMIZATION_LEVEL > 2 else OPTIMIZATION_LEVEL
+
 RUN_ARGS_COMMON = [
     "staq",
     "-S",
     f"-O{OPTIMIZATION_LEVEL}",
-    "-c",
     "-l",
     LAYOUT,
     "-M",

--- a/benchpress/staq_gym/device_transpile/test_summit.py
+++ b/benchpress/staq_gym/device_transpile/test_summit.py
@@ -36,7 +36,7 @@ OPTIMIZATION_LEVEL = Configuration.options["staq"]["optimization_level"]
 # Truncating OPTIMIZATION_LEVEL to max 2
 # OPTIMIZATION_LEVEL=3 uses a `--cnot-resynthesis` flag
 # that removes qubit connectivity
-OPTIMIZATION_LEVEL = 2 if OPTIMIZATION_LEVEL > 2 else OPTIMIZATION_LEVEL
+OPTIMIZATION_LEVEL = min(2, OPTIMIZATION_LEVEL)
 
 RUN_ARGS_COMMON = [
     "staq",

--- a/benchpress/workouts/build/circuit_construction.py
+++ b/benchpress/workouts/build/circuit_construction.py
@@ -69,7 +69,7 @@ class WorkoutCircuitConstruction:
         """
         pass
 
-    @pytest.mark.skip(reason="Not implimented")
+    @pytest.mark.skip(reason="Not implemented")
     def test_bigint_qasm2_import(self, benchmark):
         """Try importing a QASM file with a bigint
         """

--- a/default.conf
+++ b/default.conf
@@ -19,6 +19,6 @@ optimization_level = 2
 maxwidth = 500
 
 [staq]
-optimization_level = 2
+optimization_level = 2 # Setting this higher removes qubit connectivity
 layout = 'bestfit'
 mapping = 'swap'


### PR DESCRIPTION
This PR removes `-c` (`--cnot-resynthesis`) flag from Staq as the flag does not preserve qubit connectivity.
Staq OPTIMIZATION-LEVEL=3 (`-O3`) uses the `-c` inside it. Therefore, the OPTIMIZATION-LEVEL is truncated to max 2.