### PR TITLE
Add input circuit statistics

### DIFF
--- a/benchpress/bqskit_gym/abstract_transpile/test_hamiltonians.py
+++ b/benchpress/bqskit_gym/abstract_transpile/test_hamiltonians.py
@@ -16,7 +16,7 @@ from bqskit import compile
 from bqskit.compiler import Compiler
 
 from benchpress.bqskit_gym.utils.bqskit_backend_utils import BqskitFlexibleBackend
-from benchpress.utilities.io import output_circuit_properties
+from benchpress.utilities.io import input_circuit_properties, output_circuit_properties
 from benchpress.utilities.io.hamiltonians import generate_hamiltonian_circuit
 from benchpress.workouts.validation import benchpress_test_validation
 from benchpress.config import Configuration
@@ -39,6 +39,7 @@ class TestWorkoutAbstractHamiltonians(WorkoutAbstractHamiltonians):
         circuit = generate_hamiltonian_circuit(
             circ_and_topo[0].pop("ham_hamlib_hamiltonian"), benchmark
         )
+        input_circuit_properties(circuit, benchmark)
         BACKEND = BqskitFlexibleBackend(circuit.num_qudits, circ_and_topo[1])
         TWO_Q_GATE = BACKEND.two_q_gate_type
         compiler = Compiler()

--- a/benchpress/bqskit_gym/device_transpile/test_hamiltonians.py
+++ b/benchpress/bqskit_gym/device_transpile/test_hamiltonians.py
@@ -18,7 +18,7 @@ from bqskit.compiler import Compiler
 from qiskit.quantum_info import SparsePauliOp
 
 from benchpress.config import Configuration
-from benchpress.utilities.io import output_circuit_properties
+from benchpress.utilities.io import input_circuit_properties, output_circuit_properties
 from benchpress.utilities.io.hamiltonians import generate_hamiltonian_circuit
 from benchpress.workouts.validation import benchpress_test_validation
 from benchpress.workouts.device_transpile import WorkoutDeviceHamlibHamiltonians
@@ -52,6 +52,7 @@ class TestWorkoutDeviceHamlibHamiltonians(WorkoutDeviceHamlibHamiltonians):
         circuit = generate_hamiltonian_circuit(
             hamiltonian_info.pop("ham_hamlib_hamiltonian"), benchmark
         )
+        input_circuit_properties(circuit, benchmark)
         compiler = Compiler()
 
         @benchmark

--- a/benchpress/bqskit_gym/device_transpile/test_summit.py
+++ b/benchpress/bqskit_gym/device_transpile/test_summit.py
@@ -20,7 +20,9 @@ from benchpress.bqskit_gym.circuits import (
     trivial_bvlike_circuit,
 )
 from benchpress.config import Configuration
-from benchpress.utilities.io import qasm_circuit_loader, output_circuit_properties
+from benchpress.utilities.io import (qasm_circuit_loader,
+                                     input_circuit_properties,
+                                     output_circuit_properties)
 from benchpress.utilities.validation import circuit_validator
 from benchpress.workouts.validation import benchpress_test_validation
 from benchpress.workouts.device_transpile import WorkoutDeviceTranspile100Q
@@ -78,6 +80,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
     def test_circSU2_89_transpile(self, benchmark):
         """Compile 89Q circSU2 circuit against target backend"""
         circuit = bqskit_circSU2(89, 3)
+        input_circuit_properties(circuit, benchmark)
         compiler = Compiler()
 
         @benchmark
@@ -97,6 +100,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
     def test_circSU2_100_transpile(self, benchmark):
         """Compile 100Q circSU2 circuit against target backend"""
         circuit = bqskit_circSU2(100, 3)
+        input_circuit_properties(circuit, benchmark)
         compiler = Compiler()
 
         @benchmark
@@ -116,6 +120,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
     def test_BV_100_transpile(self, benchmark):
         """Compile 100Q BV circuit against target backend"""
         circuit = bqskit_bv_all_ones(100)
+        input_circuit_properties(circuit, benchmark)
         compiler = Compiler()
 
         @benchmark
@@ -182,6 +187,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
         into a single X and Z gate on a target device
         """
         circuit = trivial_bvlike_circuit(100)
+        input_circuit_properties(circuit, benchmark)
         compiler = Compiler()
 
         @benchmark

--- a/benchpress/bqskit_gym/utils/io.py
+++ b/benchpress/bqskit_gym/utils/io.py
@@ -43,6 +43,9 @@ def bqskit_hamiltonian_circuit(sparse_op, label=None, evo_time=1):
         qiskit_hamiltonian_circuit(sparse_op, label, evo_time).decompose().decompose()
     )
 
+def bqskit_input_circuit_properties(circuit, benchmark):
+    benchmark.extra_info["input_num_qubits"] = circuit.num_qudits
+
 
 def bqskit_output_circuit_properties(circuit, two_qubit_gate, benchmark):
     ops = {}

--- a/benchpress/braket_gym/utils/io.py
+++ b/benchpress/braket_gym/utils/io.py
@@ -34,6 +34,14 @@ def braket_qasm_loader(qasm_file, benchmark):
     benchmark.extra_info["input_num_qubits"] = circuit.qubit_count
     return circuit
 
+def braket_input_circuit_properties(circuit, benchmark):
+    """Get cirq output circuit statistics
+
+    Parameters:
+        circuit (Circuit): Input Cirq circuit
+        benchmark : The benchmark object
+    """
+    benchmark.extra_info["input_num_qubits"] = circuit.qubit_count
 
 def braket_output_circuit_properties(circuit, two_qubit_gate, benchmark):
     """Get cirq output circuit statistics

--- a/benchpress/cirq_gym/utils/io.py
+++ b/benchpress/cirq_gym/utils/io.py
@@ -33,6 +33,15 @@ def cirq_qasm_loader(qasm_file, benchmark):
     benchmark.extra_info["input_num_qubits"] = cirq.num_qubits(circuit)
     return circuit
 
+def cirq_input_circuit_properties(circuit, benchmark):
+    """Get cirq output circuit statistics
+
+    Parameters:
+        circuit (Circuit): Input Cirq circuit
+        benchmark : The benchmark object
+    """
+    benchmark.extra_info["input_num_qubits"] = cirq.num_qubits(circuit)
+
 
 def cirq_output_circuit_properties(circuit, two_qubit_gate, benchmark):
     """Get cirq output circuit statistics

--- a/benchpress/qiskit_gym/abstract_transpile/test_hamiltonians.py
+++ b/benchpress/qiskit_gym/abstract_transpile/test_hamiltonians.py
@@ -15,7 +15,7 @@ import pytest
 
 from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 
-from benchpress.utilities.io import output_circuit_properties
+from benchpress.utilities.io import input_circuit_properties, output_circuit_properties
 from benchpress.utilities.io.hamiltonians import generate_hamiltonian_circuit
 from benchpress.workouts.validation import benchpress_test_validation
 from benchpress.config import Configuration
@@ -39,6 +39,7 @@ class TestWorkoutAbstractHamiltonians(WorkoutAbstractHamiltonians):
         circuit = generate_hamiltonian_circuit(
             circ_and_topo[0].pop("ham_hamlib_hamiltonian"), benchmark
         )
+        input_circuit_properties(circuit, benchmark)
         backend = FlexibleBackend(circuit.num_qubits, circ_and_topo[1])
         TWO_Q_GATE = backend.two_q_gate_type
         pm = generate_preset_pass_manager(

--- a/benchpress/qiskit_gym/device_transpile/test_hamiltonians.py
+++ b/benchpress/qiskit_gym/device_transpile/test_hamiltonians.py
@@ -17,7 +17,7 @@ from qiskit.quantum_info import SparsePauliOp
 from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 
 from benchpress.config import Configuration
-from benchpress.utilities.io import output_circuit_properties
+from benchpress.utilities.io import input_circuit_properties, output_circuit_properties
 from benchpress.utilities.io.hamiltonians import generate_hamiltonian_circuit
 from benchpress.workouts.validation import benchpress_test_validation
 from benchpress.workouts.device_transpile import WorkoutDeviceHamlibHamiltonians
@@ -52,6 +52,7 @@ class TestWorkoutDeviceHamlibHamiltonians(WorkoutDeviceHamlibHamiltonians):
         circuit = generate_hamiltonian_circuit(
             hamiltonian_info.pop("ham_hamlib_hamiltonian"), benchmark
         )
+        input_circuit_properties(circuit, benchmark)
 
         @benchmark
         def result():

--- a/benchpress/qiskit_gym/device_transpile/test_summit.py
+++ b/benchpress/qiskit_gym/device_transpile/test_summit.py
@@ -6,7 +6,8 @@ from qiskit.transpiler.passes import StarPreRouting
 from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 
 from benchpress.config import Configuration
-from benchpress.utilities.io import qasm_circuit_loader, output_circuit_properties
+from benchpress.utilities.io import (qasm_circuit_loader, input_circuit_properties,
+                                     output_circuit_properties)
 from benchpress.utilities.validation import circuit_validator
 from benchpress.qiskit_gym.circuits import bv_all_ones
 
@@ -57,6 +58,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
     def test_circSU2_89_transpile(self, benchmark):
         """Compile 89Q circSU2 circuit against target backend"""
         circuit = EfficientSU2(89, reps=3, entanglement="circular")
+        input_circuit_properties(circuit, benchmark)
         pm = generate_preset_pass_manager(OPTIMIZATION_LEVEL, BACKEND)
 
         @benchmark
@@ -70,6 +72,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
     def test_circSU2_100_transpile(self, benchmark):
         """Compile 100Q circSU2 circuit against target backend"""
         circuit = EfficientSU2(100, reps=3, entanglement="circular")
+        input_circuit_properties(circuit, benchmark)
         pm = generate_preset_pass_manager(OPTIMIZATION_LEVEL, BACKEND)
 
         @benchmark
@@ -83,6 +86,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
     def test_BV_100_transpile(self, benchmark):
         """Compile 100Q BV circuit against target backend"""
         circuit = bv_all_ones(100)
+        input_circuit_properties(circuit, benchmark)
         pm = generate_preset_pass_manager(OPTIMIZATION_LEVEL, BACKEND)
 
         @benchmark
@@ -131,6 +135,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
         into a single X and Z gate on a target device
         """
         circuit = trivial_bvlike_circuit(100)
+        input_circuit_properties(circuit, benchmark)
         pm = generate_preset_pass_manager(OPTIMIZATION_LEVEL, BACKEND)
 
         @benchmark

--- a/benchpress/qiskit_gym/utils/io.py
+++ b/benchpress/qiskit_gym/utils/io.py
@@ -33,6 +33,10 @@ def qiskit_hamiltonian_circuit(sparse_op, label=None, evo_time=1):
     return qc
 
 
+def qiskit_input_circuit_properties(circuit, benchmark):
+    benchmark.extra_info["input_num_qubits"] = circuit.num_qubits
+
+
 def qiskit_output_circuit_properties(circuit, two_qubit_gate, benchmark):
     benchmark.extra_info["output_num_qubits"] = circuit.num_qubits
     benchmark.extra_info["output_circuit_operations"] = circuit.count_ops()

--- a/benchpress/qiskit_transpiler_service_gym/abstract_transpile/test_hamiltonians.py
+++ b/benchpress/qiskit_transpiler_service_gym/abstract_transpile/test_hamiltonians.py
@@ -15,7 +15,7 @@ import pytest
 
 from qiskit_transpiler_service.transpiler_service import TranspilerService
 
-from benchpress.utilities.io import output_circuit_properties
+from benchpress.utilities.io import input_circuit_properties, output_circuit_properties
 from benchpress.utilities.io.hamiltonians import generate_hamiltonian_circuit
 from benchpress.workouts.validation import benchpress_test_validation
 from benchpress.config import Configuration
@@ -39,6 +39,7 @@ class TestWorkoutAbstractHamiltonians(WorkoutAbstractHamiltonians):
         circuit = generate_hamiltonian_circuit(
             circ_and_topo[0].pop("ham_hamlib_hamiltonian"), benchmark
         )
+        input_circuit_properties(circuit, benchmark)
         BACKEND = FlexibleBackend(circuit.num_qubits, circ_and_topo[1])
         TWO_Q_GATE = BACKEND.two_q_gate_type
         TRANS_SERVICE = TranspilerService(

--- a/benchpress/qiskit_transpiler_service_gym/device_transpile/test_hamiltonians.py
+++ b/benchpress/qiskit_transpiler_service_gym/device_transpile/test_hamiltonians.py
@@ -17,7 +17,7 @@ from qiskit.quantum_info import SparsePauliOp
 from qiskit_transpiler_service.transpiler_service import TranspilerService
 
 from benchpress.config import Configuration
-from benchpress.utilities.io import output_circuit_properties
+from benchpress.utilities.io import input_circuit_properties, output_circuit_properties
 from benchpress.utilities.io.hamiltonians import generate_hamiltonian_circuit
 from benchpress.workouts.validation import benchpress_test_validation
 from benchpress.workouts.device_transpile import WorkoutDeviceHamlibHamiltonians
@@ -58,6 +58,7 @@ class TestWorkoutDeviceHamlibHamiltonians(WorkoutDeviceHamlibHamiltonians):
         circuit = generate_hamiltonian_circuit(
             hamiltonian_info.pop("ham_hamlib_hamiltonian"), benchmark
         )
+        input_circuit_properties(circuit, benchmark)
 
         @benchmark
         def result():

--- a/benchpress/qiskit_transpiler_service_gym/device_transpile/test_summit.py
+++ b/benchpress/qiskit_transpiler_service_gym/device_transpile/test_summit.py
@@ -17,7 +17,8 @@ from qiskit_transpiler_service.transpiler_service import TranspilerService
 
 from benchpress.config import Configuration
 from benchpress.qiskit_gym.circuits import bv_all_ones
-from benchpress.utilities.io import qasm_circuit_loader, output_circuit_properties
+from benchpress.utilities.io import (qasm_circuit_loader, input_circuit_properties,
+                                     output_circuit_properties)
 from benchpress.utilities.validation import circuit_validator
 from benchpress.workouts.validation import benchpress_test_validation
 from benchpress.workouts.device_transpile import WorkoutDeviceTranspile100Q
@@ -68,7 +69,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
     def test_circSU2_89_transpile(self, benchmark):
         """Compile 89Q circSU2 circuit against target backend"""
         circuit = EfficientSU2(89, reps=3, entanglement="circular")
-
+        input_circuit_properties(circuit, benchmark)
         @benchmark
         def result():
             trans_qc = TRANS_SERVICE.run(circuit)
@@ -80,7 +81,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
     def test_circSU2_100_transpile(self, benchmark):
         """Compile 100Q circSU2 circuit against target backend"""
         circuit = EfficientSU2(100, reps=3, entanglement="circular")
-
+        input_circuit_properties(circuit, benchmark)
         @benchmark
         def result():
             trans_qc = TRANS_SERVICE.run(circuit)
@@ -92,7 +93,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
     def test_BV_100_transpile(self, benchmark):
         """Compile 100Q BV circuit against target backend"""
         circuit = bv_all_ones(100)
-
+        input_circuit_properties(circuit, benchmark)
         @benchmark
         def result():
             trans_qc = TRANS_SERVICE.run(circuit)
@@ -137,7 +138,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
         into a single X and Z gate on a target device
         """
         circuit = trivial_bvlike_circuit(100)
-
+        input_circuit_properties(circuit, benchmark)
         @benchmark
         def result():
             trans_qc = TRANS_SERVICE.run(circuit)

--- a/benchpress/staq_gym/device_transpile/test_summit.py
+++ b/benchpress/staq_gym/device_transpile/test_summit.py
@@ -18,7 +18,8 @@ from qiskit import QuantumCircuit, qasm2
 from qiskit.circuit.library import EfficientSU2
 
 from benchpress.config import Configuration
-from benchpress.utilities.io import output_circuit_properties
+from benchpress.utilities.io import (qasm_circuit_loader, input_circuit_properties,
+                                     output_circuit_properties)
 from benchpress.utilities.validation import circuit_validator
 from benchpress.qiskit_gym.circuits import bv_all_ones, trivial_bvlike_circuit
 from benchpress.workouts.device_transpile import WorkoutDeviceTranspile100Q
@@ -70,7 +71,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
         device = staq_device(backend=BACKEND)
         qasm_file = "qft_N100.qasm"
         input_qasm_file = Configuration.get_qasm_dir("qft") + qasm_file
-
+        _ = qasm_circuit_loader(input_qasm_file, benchmark)
         @benchmark
         def result():
             out = subprocess.run(
@@ -91,7 +92,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
         device = staq_device(backend=BACKEND)
         qasm_file = "qv_N100_12345.qasm"
         input_qasm_file = Configuration.get_qasm_dir("qv") + qasm_file
-
+        _ = qasm_circuit_loader(input_qasm_file, benchmark)
         @benchmark
         def result():
             out = subprocess.run(
@@ -111,7 +112,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
         """Compile 89Q circSU2 circuit against target backend"""
         device = staq_device(backend=BACKEND)
         circuit = EfficientSU2(89, reps=3, entanglement="circular")
-
+        input_circuit_properties(circuit, benchmark)
         # staq works on qasm files only & qasm files need bounded params
         num_parameters = circuit.num_parameters
         np.random.seed(0)
@@ -139,7 +140,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
         """Compile 100Q circSU2 circuit against target backend"""
         device = staq_device(backend=BACKEND)
         circuit = EfficientSU2(100, reps=3, entanglement="circular")
-
+        input_circuit_properties(circuit, benchmark)
         # staq works on qasm files only & qasm files need bounded params
         num_parameters = circuit.num_parameters
         np.random.seed(0)
@@ -167,7 +168,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
         """Compile 100Q BV circuit against target backend"""
         device = staq_device(backend=BACKEND)
         circuit = bv_all_ones(100)
-
+        input_circuit_properties(circuit, benchmark)
         base_temp_dir = tmp_path_factory.getbasetemp()
         input_qasm_file = base_temp_dir / "circ.qasm"
         qasm2.dump(circuit, input_qasm_file)
@@ -190,7 +191,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
         device = staq_device(backend=BACKEND)
         qasm_file = "square_heisenberg_N100.qasm"
         input_qasm_file = Configuration.get_qasm_dir("square-heisenberg") + qasm_file
-
+        _ = qasm_circuit_loader(input_qasm_file, benchmark)
         @benchmark
         def result():
             out = subprocess.run(
@@ -209,7 +210,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
         device = staq_device(backend=BACKEND)
         qasm_file = "qaoa_barabasi_albert_N100_3reps.qasm"
         input_qasm_file = Configuration.get_qasm_dir("qaoa") + qasm_file
-
+        _ = qasm_circuit_loader(input_qasm_file, benchmark)
         @benchmark
         def result():
             out = subprocess.run(
@@ -231,7 +232,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
         """
         device = staq_device(backend=BACKEND)
         circuit = trivial_bvlike_circuit(100)
-
+        input_circuit_properties(circuit, benchmark)
         base_temp_dir = tmp_path_factory.getbasetemp()
         input_qasm_file = base_temp_dir / "trivial_bvlike_100.qasm"
         qasm2.dump(circuit, input_qasm_file)
@@ -254,7 +255,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
         device = staq_device(backend=BACKEND)
         qasm_file = "clifford_100_12345.qasm"
         input_qasm_file = Configuration.get_qasm_dir("clifford") + qasm_file
-
+        _ = qasm_circuit_loader(input_qasm_file, benchmark)
         @benchmark
         def result():
             out = subprocess.run(

--- a/benchpress/staq_gym/utils/io.py
+++ b/benchpress/staq_gym/utils/io.py
@@ -10,6 +10,9 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
+def staq_input_circuit_properties(circuit, benchmark):
+    benchmark.extra_info["input_num_qubits"] = circuit.num_qubits
+
 
 def staq_output_circuit_properties(circuit, two_qubit_gate, benchmark):
     benchmark.extra_info["output_num_qubits"] = circuit.num_qubits

--- a/benchpress/tket_gym/abstract_transpile/test_hamiltonians.py
+++ b/benchpress/tket_gym/abstract_transpile/test_hamiltonians.py
@@ -14,7 +14,7 @@
 import pytest
 
 from benchpress.tket_gym.utils.tket_backend_utils import TketFlexibleBackend
-from benchpress.utilities.io import output_circuit_properties
+from benchpress.utilities.io import input_circuit_properties, output_circuit_properties
 from benchpress.utilities.io.hamiltonians import generate_hamiltonian_circuit
 from benchpress.workouts.validation import benchpress_test_validation
 from benchpress.config import Configuration
@@ -37,6 +37,7 @@ class TestWorkoutAbstractHamiltonians(WorkoutAbstractHamiltonians):
         circuit = generate_hamiltonian_circuit(
             circ_and_topo[0].pop("ham_hamlib_hamiltonian"), benchmark
         )
+        input_circuit_properties(circuit, backend)
         backend = TketFlexibleBackend(circuit.n_qubits, circ_and_topo[1])
         TWO_Q_GATE = backend.two_q_gate_type
 

--- a/benchpress/tket_gym/device_transpile/test_hamiltonians.py
+++ b/benchpress/tket_gym/device_transpile/test_hamiltonians.py
@@ -15,7 +15,7 @@ import pytest
 from qiskit.quantum_info import SparsePauliOp
 
 from benchpress.config import Configuration
-from benchpress.utilities.io import output_circuit_properties
+from benchpress.utilities.io import input_circuit_properties, output_circuit_properties
 from benchpress.utilities.io.hamiltonians import generate_hamiltonian_circuit
 from benchpress.workouts.validation import benchpress_test_validation
 from benchpress.workouts.device_transpile import WorkoutDeviceHamlibHamiltonians
@@ -50,6 +50,7 @@ class TestWorkoutDeviceHamlibHamiltonians(WorkoutDeviceHamlibHamiltonians):
         circuit = generate_hamiltonian_circuit(
             hamiltonian_info.pop("ham_hamlib_hamiltonian"), benchmark
         )
+        input_circuit_properties(circuit, benchmark)
 
         @benchmark
         def result():

--- a/benchpress/tket_gym/device_transpile/test_summit.py
+++ b/benchpress/tket_gym/device_transpile/test_summit.py
@@ -13,7 +13,8 @@
 
 from benchpress.config import Configuration
 from benchpress.tket_gym.circuits import tket_bv_all_ones, tket_circSU2
-from benchpress.utilities.io import qasm_circuit_loader, output_circuit_properties
+from benchpress.utilities.io import (qasm_circuit_loader, input_circuit_properties,
+                                     output_circuit_properties)
 from benchpress.utilities.validation import circuit_validator
 
 from benchpress.workouts.validation import benchpress_test_validation
@@ -64,6 +65,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
     def test_circSU2_89_transpile(self, benchmark):
         """Compile 89Q circSU2 circuit against target backend"""
         circuit = tket_circSU2(89, 3)
+        input_circuit_properties(circuit, benchmark)
         pm = BACKEND.default_compilation_pass(optimisation_level=OPTIMIZATION_LEVEL)
 
         @benchmark
@@ -79,6 +81,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
     def test_circSU2_100_transpile(self, benchmark):
         """Compile 100Q circSU2 circuit against target backend"""
         circuit = tket_circSU2(100, 3)
+        input_circuit_properties(circuit, benchmark)
         pm = BACKEND.default_compilation_pass(optimisation_level=OPTIMIZATION_LEVEL)
 
         @benchmark
@@ -94,6 +97,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
     def test_BV_100_transpile(self, benchmark):
         """Compile 100Q BV circuit against target backend"""
         circuit = tket_bv_all_ones(100)
+        input_circuit_properties(circuit, benchmark)
         pm = BACKEND.default_compilation_pass(optimisation_level=OPTIMIZATION_LEVEL)
 
         @benchmark
@@ -148,6 +152,7 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
         into a single X and Z gate on a target device
         """
         circuit = trivial_bvlike_circuit(100)
+        input_circuit_properties(circuit, benchmark)
         pm = BACKEND.default_compilation_pass(optimisation_level=OPTIMIZATION_LEVEL)
 
         @benchmark

--- a/benchpress/tket_gym/utils/io.py
+++ b/benchpress/tket_gym/utils/io.py
@@ -56,6 +56,10 @@ def tket_hamiltonian_circuit(sparse_op, label=None, evo_time=1):
     return gen_term_sequence_circuit(tket_op, qc)
 
 
+def tket_input_circuit_properties(circuit, benchmark):
+    benchmark.extra_info["input_num_qubits"] = circuit.n_qubits
+
+
 def tket_output_circuit_properties(circuit, two_qubit_gate, benchmark):
     ops = {}
     for command in circuit.get_commands():

--- a/benchpress/utilities/io/circuit_input.py
+++ b/benchpress/utilities/io/circuit_input.py
@@ -1,0 +1,55 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""QASMbench utilities"""
+
+from benchpress.config import Configuration
+
+
+def input_circuit_properties(circuit, benchmark):
+    """Return input circuit statistics
+
+    circuit : Input quantum circuit
+    benchmark (Benchmark): Benchmark class to record info to
+
+    """
+    gym_name = Configuration.gym_name
+    if gym_name in ["qiskit", "qiskit-transpiler-service"]:
+        from benchpress.qiskit_gym.utils.io import qiskit_input_circuit_properties
+
+        qiskit_input_circuit_properties(circuit, benchmark)
+
+    elif gym_name == "tket":
+        from benchpress.tket_gym.utils.io import tket_input_circuit_properties
+
+        tket_input_circuit_properties(circuit, benchmark)
+
+    elif gym_name == "bqskit":
+        from benchpress.bqskit_gym.utils.io import bqskit_input_circuit_properties
+
+        bqskit_input_circuit_properties(circuit, benchmark)
+
+    elif gym_name == "staq":
+        from benchpress.staq_gym.utils.io import staq_input_circuit_properties
+
+        staq_input_circuit_properties(circuit, benchmark)
+
+    elif gym_name == "braket":
+        from benchpress.braket_gym.utils.io import braket_input_circuit_properties
+
+        braket_input_circuit_properties(circuit, benchmark)
+
+    elif gym_name == "cirq":
+        from benchpress.cirq_gym.utils.io import cirq_input_circuit_properties
+
+        cirq_input_circuit_properties(circuit, benchmark)
+    else:
+        raise Exception(f"Unsupported gym name {gym_name}")


### PR DESCRIPTION
One of the important circuit metrics to consider is the number of qubits (width) of the input circuit.  We were collecting this for some of the transpilation circuits, but not all.