### PR TITLE
Update Braket to run all tests

### DIFF
--- a/benchpress/braket_gym/abstract_transpile/test_hamiltonians.py
+++ b/benchpress/braket_gym/abstract_transpile/test_hamiltonians.py
@@ -1,0 +1,22 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""Test Hamiltonians against abstract backend topologies"""
+from benchpress.workouts.validation import benchpress_test_validation
+
+
+from benchpress.workouts.abstract_transpile.hamlib_hamiltonians import (
+    WorkoutAbstractHamiltonians,
+)
+
+@benchpress_test_validation
+class TestWorkoutAbstractHamiltonians(WorkoutAbstractHamiltonians):
+    pass

--- a/benchpress/braket_gym/device_transpile/test_feynman.py
+++ b/benchpress/braket_gym/device_transpile/test_feynman.py
@@ -1,0 +1,32 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""Test transpilation against a device"""
+import os
+import pytest
+
+
+from benchpress.config import Configuration
+from benchpress.workouts.validation import benchpress_test_validation
+from benchpress.workouts.device_transpile import WorkoutDeviceFeynman
+
+
+def pytest_generate_tests(metafunc):
+    directory = Configuration.get_qasm_dir("feynman")
+    file_list = [x for x in os.listdir(directory) if x.endswith(".qasm")]
+    metafunc.parametrize("filename", file_list)
+
+
+@benchpress_test_validation
+class TestWorkoutDeviceFeynman(WorkoutDeviceFeynman):
+
+    def test_feynman_transpile(self, benchmark, filename):
+        pytest.skip("Not implimented")

--- a/benchpress/braket_gym/device_transpile/test_hamiltonians.py
+++ b/benchpress/braket_gym/device_transpile/test_hamiltonians.py
@@ -1,0 +1,38 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""Test transpilation against a device"""
+import json
+import pytest
+from qiskit.quantum_info import SparsePauliOp
+from benchpress.config import Configuration
+from benchpress.workouts.validation import benchpress_test_validation
+from benchpress.workouts.device_transpile import WorkoutDeviceHamlibHamiltonians
+
+
+
+def pytest_generate_tests(metafunc):
+    directory = Configuration.get_hamiltonian_dir("hamlib")
+    ham_records = json.load(open(directory + "100_representative.json", "r"))
+    for h in ham_records:
+        terms = h.pop("ham_hamlib_hamiltonian_terms")
+        coefficients = h.pop("ham_hamlib_hamiltonian_coefficients")
+        h["ham_hamlib_hamiltonian"] = SparsePauliOp(terms, coefficients)
+    metafunc.parametrize(
+        "hamiltonian_info", ham_records, ids=lambda x: "ham_" + x["ham_instance"][1:-1]
+    )
+
+
+@benchpress_test_validation
+class TestWorkoutDeviceHamlibHamiltonians(WorkoutDeviceHamlibHamiltonians):
+
+    def test_hamlib_hamiltonians_transpile(self, benchmark, hamiltonian_info):
+        pytest.skip("Not implimented")

--- a/requirements-braket.txt
+++ b/requirements-braket.txt
@@ -1,2 +1,3 @@
 amazon-braket-sdk
+qiskit
 git+https://github.com/1ucian0/pytest-benchmark.git@timeout-skiplist/fork/decorator


### PR DESCRIPTION
Braket was not skipping all the tests because the workouts were not added.  This fixes that so that Braket now runs all 1066 tests, skipping the vast majority of them.