### PR TITLE
fix bqskit construct tests

### DIFF
--- a/benchpress/bqskit_gym/construct/test_build.py
+++ b/benchpress/bqskit_gym/construct/test_build.py
@@ -42,7 +42,7 @@ class TestWorkoutCircuitConstruction(WorkoutCircuitConstruction):
             bqskit_QV(100, 100, seed=SEED)
             return True
 
-        assert output_circuit_properties(result, benchmark)
+        assert result
 
     def test_DTC100_set_build(self, benchmark):
         """Measures an SDKs ability to build a set
@@ -64,7 +64,6 @@ class TestWorkoutCircuitConstruction(WorkoutCircuitConstruction):
             return circs[-1]
 
         assert result.gate_counts[RZZGate()] == 9900
-        assert output_circuit_properties(result, benchmark)
 
     @pytest.mark.xfail(
         reason="Runs out of memory (128GB RAM) for 16Q MCX gate", run=False
@@ -80,7 +79,7 @@ class TestWorkoutCircuitConstruction(WorkoutCircuitConstruction):
             out = multi_control_circuit(ITER_CIRCUIT_WIDTH)
             return out
 
-        assert output_circuit_properties(result, benchmark)
+        assert result
 
     def test_clifford_build(self, benchmark):
         """Measures an SDKs ability to build a 100Q
@@ -108,7 +107,6 @@ class TestWorkoutCircuitConstruction(WorkoutCircuitConstruction):
             return out
 
         assert result.num_params == 1000
-        assert output_circuit_properties(result, benchmark)
 
     def test_param_circSU2_100_bind(self, benchmark):
         """Measures an SDKs ability to bind 1000 parameters
@@ -126,7 +124,7 @@ class TestWorkoutCircuitConstruction(WorkoutCircuitConstruction):
             out.set_params(params)
             return out
 
-        assert output_circuit_properties(result, benchmark)
+        assert result
 
     def test_QV100_qasm2_import(self, benchmark):
         """QASM import of QV100 circuit"""
@@ -141,7 +139,6 @@ class TestWorkoutCircuitConstruction(WorkoutCircuitConstruction):
         assert result.gate_counts[RZGate()] == 120000
         assert result.gate_counts[RXGate()] == 80000
         assert result.gate_counts[CXGate()] == 15000
-        assert output_circuit_properties(result, benchmark)
 
     def test_bigint_qasm2_import(self, benchmark):
         """QASM import of QV100 circuit"""
@@ -153,4 +150,4 @@ class TestWorkoutCircuitConstruction(WorkoutCircuitConstruction):
             )
             return out
 
-        assert output_circuit_properties(result, benchmark)
+        assert result


### PR DESCRIPTION
I tried to use the output circuit properties on tests that it should not have been used on by accident.