### PR TITLE
Remove star routing from Qiskit QFT

### DIFF
--- a/benchpress/qiskit_gym/device_transpile/test_summit.py
+++ b/benchpress/qiskit_gym/device_transpile/test_summit.py
@@ -1,8 +1,6 @@
 """Test summit benchmarks"""
 
-from qiskit import QuantumCircuit
 from qiskit.circuit.library import EfficientSU2
-from qiskit.transpiler.passes import StarPreRouting
 from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 
 from benchpress.config import Configuration
@@ -30,7 +28,6 @@ class TestWorkoutDeviceTranspile100Q(WorkoutDeviceTranspile100Q):
         )
 
         pm = generate_preset_pass_manager(OPTIMIZATION_LEVEL, BACKEND)
-        pm.init.append(StarPreRouting())
 
         @benchmark
         def result():


### PR DESCRIPTION
At present, we only consider default transpilation pipelines in Benchpress. As such, this PR removes the star pre-routing step from the Qiskit QFT device transpile test.