### PR TITLE
Renaming qiskit-transpiler-service project to the new name qiskit-ibm-transpiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Benchpress currently supports the following SDKs:
 - **Braket** (https://github.com/amazon-braket/amazon-braket-sdk-python)
 - **Cirq** (https://github.com/quantumlib/Cirq)
 - **Qiskit** (https://github.com/Qiskit/qiskit)
-- **Qiskit-Transpiler-Service** (https://github.com/Qiskit/qiskit-transpiler-service)
+- **Qiskit IBM transpiler** (https://github.com/Qiskit/qiskit-ibm-transpiler)
 - **Staq** (https://github.com/softwareQinc/staq)
 - **Tket** (https://github.com/CQCL/tket)
 
@@ -105,4 +105,3 @@ Benchpress makes use of files from the following open-source packages under term
 ## License
 
 [Apache License 2.0](LICENSE.txt)
-

--- a/benchpress/config.py
+++ b/benchpress/config.py
@@ -94,7 +94,7 @@ class BenchpressConfig:
             "qiskit",
             "tket",
             "bqskit",
-            "qiskit-transpiler-service",
+            "qiskit-ibm-transpiler",
             "staq",
         ]:
             backend = get_backend(

--- a/benchpress/qiskit_transpiler_service_gym/__init__.py
+++ b/benchpress/qiskit_transpiler_service_gym/__init__.py
@@ -12,4 +12,4 @@
 
 from benchpress.config import Configuration
 
-Configuration.gym_name = "qiskit-transpiler-service"
+Configuration.gym_name = "qiskit-ibm-transpiler"

--- a/benchpress/utilities/backends/backend_utils.py
+++ b/benchpress/utilities/backends/backend_utils.py
@@ -12,7 +12,7 @@
 
 
 def get_backend(backend_name: str, gym_name: str):
-    if gym_name in ["qiskit", "qiskit-transpiler-service"]:
+    if gym_name in ["qiskit", "qiskit-ibm-transpiler"]:
         from benchpress.qiskit_gym.utils.qiskit_backend_utils import (
             get_qiskit_bench_backend,
         )

--- a/benchpress/utilities/io/circuit_input.py
+++ b/benchpress/utilities/io/circuit_input.py
@@ -22,7 +22,7 @@ def input_circuit_properties(circuit, benchmark):
 
     """
     gym_name = Configuration.gym_name
-    if gym_name in ["qiskit", "qiskit-transpiler-service"]:
+    if gym_name in ["qiskit", "qiskit-ibm-transpiler"]:
         from benchpress.qiskit_gym.utils.io import qiskit_input_circuit_properties
 
         qiskit_input_circuit_properties(circuit, benchmark)

--- a/benchpress/utilities/io/circuit_output.py
+++ b/benchpress/utilities/io/circuit_output.py
@@ -23,7 +23,7 @@ def output_circuit_properties(circuit, two_qubit_gate, benchmark):
 
     """
     gym_name = Configuration.gym_name
-    if gym_name in ["qiskit", "qiskit-transpiler-service"]:
+    if gym_name in ["qiskit", "qiskit-ibm-transpiler"]:
         from benchpress.qiskit_gym.utils.io import qiskit_output_circuit_properties
 
         qiskit_output_circuit_properties(circuit, two_qubit_gate, benchmark)

--- a/benchpress/utilities/io/hamiltonians.py
+++ b/benchpress/utilities/io/hamiltonians.py
@@ -27,7 +27,7 @@ def generate_hamiltonian_circuit(sparse_op, benchmark):
         The circuit instance for the corresponding SDK
     """
     gym_name = Configuration.gym_name
-    if gym_name in ["qiskit", "qiskit-transpiler-service"]:
+    if gym_name in ["qiskit", "qiskit-ibm-transpiler"]:
         from benchpress.qiskit_gym.utils.io import qiskit_hamiltonian_circuit
 
         circuit = qiskit_hamiltonian_circuit(sparse_op)

--- a/benchpress/utilities/io/qasm_loader.py
+++ b/benchpress/utilities/io/qasm_loader.py
@@ -24,7 +24,7 @@ def qasm_circuit_loader(qasm_file, benchmark):
         The circuit instance for the corresponding SDK
     """
     gym_name = Configuration.gym_name
-    if gym_name in ["qiskit", "qiskit-transpiler-service", "staq"]:
+    if gym_name in ["qiskit", "qiskit-ibm-transpiler", "staq"]:
         from benchpress.qiskit_gym.utils.io import qiskit_qasm_loader
 
         circuit = qiskit_qasm_loader(qasm_file, benchmark)

--- a/benchpress/utilities/validation/validation.py
+++ b/benchpress/utilities/validation/validation.py
@@ -23,7 +23,7 @@ def circuit_validator(circuit, backend):
         backend : Target backend
     """
     gym_name = Configuration.gym_name
-    if gym_name in ["qiskit", "qiskit-transpiler-service"]:
+    if gym_name in ["qiskit", "qiskit-ibm-transpiler"]:
         from benchpress.qiskit_gym.utils.validation import qiskit_circuit_validation
 
         qiskit_circuit_validation(circuit, backend)

--- a/requirements-qiskit-transpiler-service.txt
+++ b/requirements-qiskit-transpiler-service.txt
@@ -1,3 +1,3 @@
-qiskit-transpiler-service
+qiskit-ibm-transpiler
 qiskit-ibm-runtime
 git+https://github.com/1ucian0/pytest-benchmark.git@timeout-skiplist/forkserver/decorator


### PR DESCRIPTION
The project `qiskit-transpiler-service` is being renamed to `qiskit-ibm-transpiler` https://github.com/Qiskit/qiskit-ibm-transpiler/issues/34. This PR updates the references to that project in the main branch. 

The behavior for both libraries is exactly the same as of today (except one deprecation warning in `qiskit-transpiler-service`) so this change shouldn't affect the benchmarks. 