### PR TITLE
Use pauli_twirl_2q_gates() for twirling manipulate benchmark

### DIFF
--- a/benchpress/qiskit_gym/manipulate/test_manipulate.py
+++ b/benchpress/qiskit_gym/manipulate/test_manipulate.py
@@ -1,11 +1,7 @@
 """Test circuit manipulation"""
 
-import numpy as np
-
 from qiskit import QuantumCircuit
-from qiskit.converters import circuit_to_dag
-from qiskit.circuit import CircuitInstruction, Qubit, library
-from qiskit.dagcircuit import DAGCircuit
+from qiskit.circuit import pauli_twirl_2q_gates
 from qiskit.passmanager import PropertySet
 from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 
@@ -14,78 +10,6 @@ from benchpress.utilities.io import qasm_circuit_loader
 from benchpress.qiskit_gym.circuits import multi_control_circuit
 from benchpress.workouts.validation import benchpress_test_validation
 from benchpress.workouts.manipulate import WorkoutCircuitManipulate
-
-
-# These are all singletons.
-GATES = {
-    "id": library.IGate(),
-    "x": library.XGate(),
-    "y": library.YGate(),
-    "z": library.ZGate(),
-    "cx": library.CXGate(),
-    "cz": library.CZGate(),
-}
-TWIRLING_SETS_NAMES = {
-    "cx": [
-        ["id", "z", "z", "z"],
-        ["id", "x", "id", "x"],
-        ["id", "y", "z", "y"],
-        ["id", "id", "id", "id"],
-        ["z", "x", "z", "x"],
-        ["z", "y", "id", "y"],
-        ["z", "id", "z", "id"],
-        ["z", "z", "id", "z"],
-        ["x", "y", "y", "z"],
-        ["x", "id", "x", "x"],
-        ["x", "z", "y", "y"],
-        ["x", "x", "x", "id"],
-        ["y", "id", "y", "x"],
-        ["y", "z", "x", "y"],
-        ["y", "x", "y", "id"],
-        ["y", "y", "x", "z"],
-    ],
-    "cz": [
-        ["id", "z", "id", "z"],
-        ["id", "x", "z", "x"],
-        ["id", "y", "z", "y"],
-        ["id", "id", "id", "id"],
-        ["z", "x", "id", "x"],
-        ["z", "y", "id", "y"],
-        ["z", "id", "z", "id"],
-        ["z", "z", "z", "z"],
-        ["x", "y", "y", "x"],
-        ["x", "id", "x", "z"],
-        ["x", "z", "x", "id"],
-        ["x", "x", "y", "y"],
-        ["y", "id", "y", "z"],
-        ["y", "z", "y", "id"],
-        ["y", "x", "x", "y"],
-        ["y", "y", "x", "x"],
-    ],
-}
-TWIRLING_SETS = {
-    key: [[GATES[name] for name in twirl] for twirl in twirls]
-    for key, twirls in TWIRLING_SETS_NAMES.items()
-}
-
-
-def _dag_from_twirl(gate_2q, twirl):
-    dag = DAGCircuit()
-    # or use QuantumRegister - doesn't matter
-    qubits = (Qubit(), Qubit())
-    dag.add_qubits(qubits)
-    dag.apply_operation_back(twirl[0], (qubits[0],), (), check=False)
-    dag.apply_operation_back(twirl[1], (qubits[1],), (), check=False)
-    dag.apply_operation_back(gate_2q, qubits, (), check=False)
-    dag.apply_operation_back(twirl[2], (qubits[0],), (), check=False)
-    dag.apply_operation_back(twirl[3], (qubits[1],), (), check=False)
-    return dag
-
-
-TWIRLING_DAGS = {
-    key: [_dag_from_twirl(GATES[key], twirl) for twirl in twirls]
-    for key, twirls in TWIRLING_SETS.items()
-}
 
 
 @benchpress_test_validation
@@ -97,7 +21,7 @@ class TestWorkoutCircuitManipulate(WorkoutCircuitManipulate):
         circuit = qasm_circuit_loader(
             Configuration.get_qasm_dir("dtc") + "dtc_100_cx_12345.qasm", benchmark
         )
-        assert benchmark(circuit_twirl, circuit)
+        assert benchmark(pauli_twirl_2q_gates, circuit)
 
     def test_multi_control_decompose(self, benchmark):
         """Decompose a multi-control gate into the
@@ -163,40 +87,3 @@ class TestWorkoutCircuitManipulate(WorkoutCircuitManipulate):
             filter_function=lambda x: x.operation.name == "cz"
         )
         assert result
-
-
-def circuit_twirl(qc, twirled_gate="cx", seed=None):
-    rng = np.random.default_rng(seed)
-    twirl_set = TWIRLING_SETS.get(twirled_gate, [])
-
-    out = qc.copy_empty_like()
-    for instruction in qc.data:
-        if instruction.operation.name != twirled_gate:
-            out._append(instruction)
-        else:
-            # We could also scan through `qc` outside the loop to know how many
-            # twirled gates we'll be dealing with, and RNG the integers ahead of
-            # time - that'll be faster depending on what percentage of gates are
-            # twirled, and how much the Numpy overhead is.
-            twirls = twirl_set[rng.integers(len(twirl_set))]
-            control, target = instruction.qubits
-            out._append(CircuitInstruction(twirls[0], (control,), ()))
-            out._append(CircuitInstruction(twirls[1], (target,), ()))
-            out._append(instruction)
-            out._append(CircuitInstruction(twirls[2], (control,), ()))
-            out._append(CircuitInstruction(twirls[3], (target,), ()))
-    return out
-
-
-def dag_twirl(dag, twirled_gate="cx", seed=None):
-    # This mutates `dag` in place.
-    rng = np.random.default_rng(seed)
-    twirl_set = TWIRLING_DAGS.get(twirled_gate, [])
-    twirled_gate_op = GATES[twirled_gate].base_class
-
-    to_twirl = dag.op_nodes(twirled_gate_op)
-    twirl_indices = rng.integers(len(twirl_set), size=(len(to_twirl),))
-
-    for index, op_node in zip(twirl_indices, to_twirl):
-        dag.substitute_node_with_dag(op_node, twirl_set[index])
-    return dag

--- a/requirements-qiskit.txt
+++ b/requirements-qiskit.txt
@@ -1,3 +1,3 @@
-qiskit
+qiskit>=1.3.0rc1
 qiskit-ibm-runtime
 git+https://github.com/1ucian0/pytest-benchmark.git@timeout-skiplist/forkserver/decorator


### PR DESCRIPTION
In Qiskit 1.3.0 a dedicated function for Pauli twirling 2q gates was added to the library. This commit updates the twirling manipulate benchmark to use the new function instead of the hand written version.