### PR TITLE
Qiskit 2.0 compatibility

### DIFF
--- a/benchpress/qiskit_gym/abstract_transpile/test_hamiltonians.py
+++ b/benchpress/qiskit_gym/abstract_transpile/test_hamiltonians.py
@@ -40,7 +40,7 @@ class TestWorkoutAbstractHamiltonians(WorkoutAbstractHamiltonians):
             circ_and_topo[0].pop("ham_hamlib_hamiltonian"), benchmark
         )
         input_circuit_properties(circuit, benchmark)
-        backend = FlexibleBackend(circuit.num_qubits, circ_and_topo[1])
+        backend = FlexibleBackend(circuit.num_qubits, circ_and_topo[1], control_flow=True)
         TWO_Q_GATE = backend.two_q_gate_type
         pm = generate_preset_pass_manager(
             optimization_level=OPTIMIZATION_LEVEL, backend=backend

--- a/benchpress/qiskit_gym/abstract_transpile/test_qasmbench.py
+++ b/benchpress/qiskit_gym/abstract_transpile/test_qasmbench.py
@@ -43,7 +43,7 @@ class TestWorkoutAbstractQasmBenchSmall(WorkoutAbstractQasmBenchSmall):
     @pytest.mark.parametrize("circ_and_topo", SMALL_CIRC_TOPO, ids=SMALL_NAMES)
     def test_QASMBench_small(self, benchmark, circ_and_topo):
         circuit = qasm_circuit_loader(circ_and_topo[0], benchmark)
-        backend = FlexibleBackend(circuit.num_qubits, circ_and_topo[1])
+        backend = FlexibleBackend(circuit.num_qubits, circ_and_topo[1], control_flow=True)
         pm = generate_preset_pass_manager(
             optimization_level=OPTIMIZATION_LEVEL, backend=backend
         )
@@ -62,7 +62,7 @@ class TestWorkoutAbstractQasmBenchMedium(WorkoutAbstractQasmBenchMedium):
     @pytest.mark.parametrize("circ_and_topo", MEDIUM_CIRC_TOPO, ids=MEDIUM_NAMES)
     def test_QASMBench_medium(self, benchmark, circ_and_topo):
         circuit = qasm_circuit_loader(circ_and_topo[0], benchmark)
-        backend = FlexibleBackend(circuit.num_qubits, circ_and_topo[1])
+        backend = FlexibleBackend(circuit.num_qubits, circ_and_topo[1], control_flow=True)
         pm = generate_preset_pass_manager(
             optimization_level=OPTIMIZATION_LEVEL, backend=backend
         )
@@ -81,7 +81,7 @@ class TestWorkoutAbstractQasmBenchLarge(WorkoutAbstractQasmBenchLarge):
     @pytest.mark.parametrize("circ_and_topo", LARGE_CIRC_TOPO, ids=LARGE_NAMES)
     def test_QASMBench_large(self, benchmark, circ_and_topo):
         circuit = qasm_circuit_loader(circ_and_topo[0], benchmark)
-        backend = FlexibleBackend(circuit.num_qubits, circ_and_topo[1])
+        backend = FlexibleBackend(circuit.num_qubits, circ_and_topo[1], control_flow=True)
         pm = generate_preset_pass_manager(
             optimization_level=OPTIMIZATION_LEVEL, backend=backend
         )

--- a/benchpress/qiskit_gym/utils/qiskit_backend_utils.py
+++ b/benchpress/qiskit_gym/utils/qiskit_backend_utils.py
@@ -18,8 +18,8 @@ try:
 except ImportError:
     import qiskit.providers.fake_provider.backends as fake_backends
 from qiskit_ibm_runtime import QiskitRuntimeService
-from qiskit.providers.models.backendconfiguration import QasmBackendConfiguration
-from qiskit.providers.models.backendproperties import BackendProperties
+from qiskit_ibm_runtime.models.backend_configuration import QasmBackendConfiguration
+from qiskit_ibm_runtime.models.backend_properties import BackendProperties
 
 from benchpress.config import POSSIBLE_2Q_GATES
 

--- a/benchpress/utilities/backends/flexible_backend.py
+++ b/benchpress/utilities/backends/flexible_backend.py
@@ -15,7 +15,7 @@ import scipy.optimize as opt
 import rustworkx as rx
 
 from qiskit.providers.fake_provider import GenericBackendV2
-from qiskit.providers.models.backendconfiguration import QasmBackendConfiguration
+from qiskit_ibm_runtime.models.backend_configuration import QasmBackendConfiguration
 from qiskit.transpiler import CouplingMap
 
 from ..graphs import tree_graph, torus_coupling_map
@@ -27,7 +27,7 @@ BASIS_GATES = Configuration.options["general"]["basis_gates"]
 class FlexibleBackend(GenericBackendV2):
     """A flexible size backend"""
 
-    def __init__(self, min_qubits, layout="square", basis_gates=None):
+    def __init__(self, min_qubits, layout="square", basis_gates=None, control_flow=False):
         """Create an instance of a backend supporting, at minimum,
         a target number of qubits over a given layout (topology).
 
@@ -39,6 +39,8 @@ class FlexibleBackend(GenericBackendV2):
             basis_gates (list): Supported basis gates.  If none
                                 supplied, defaults to the global
                                 default set
+            control_flow (bool): Whether to add control flow instruction
+                support to the target or not.
         """
         if basis_gates is None:
             basis_gates = BASIS_GATES
@@ -103,13 +105,14 @@ class FlexibleBackend(GenericBackendV2):
             open_pulse=False,
             simulator=True,  # needs to be True for Tket compatibility
         )
-
-        super().__init__(num_qubits, basis_gates=self._basis_gates, coupling_map=cmap)
+        self._control_flow = control_flow
+        super().__init__(num_qubits, basis_gates=self._basis_gates, coupling_map=cmap, control_flow=control_flow)
 
     def __repr__(self):
         out = f"<FlexibleBackend(num_qubits={self.target.num_qubits}, "
         out += f"layout='{self._layout}', "
-        out += f"basis_gates={self._basis_gates}>"
+        out += f"basis_gates={self._basis_gates}, "
+        out += f"control_flow={self._control_flow})>"
         return out
 
     @property


### PR DESCRIPTION
With the pending release of Qiskit 2.0 at the end of this month there are a few small api changes that the benchpress code needs to account for. The first is that the `BackendConfiguration` objects that are used for interop with tket are no longer in Qiskit because they are IBM Quantum API payload container objects. So instead these are imported from the IBM client library package qiskit-ibm-runtime. The second change is that Qiskit 2.0 no longer supports `.c_if()` which changes how QASM2 is parsed. By default if a condition is contained in a qasm2 program this gets converted into a Qiskit `IfElseOp`. However the flexible backends used for compilation targets were not indicating they supported IfElseOp. This was causing an error for the few qasm files using conditions because the transpilation would fail because if else wasn't a supported operation. This fixes this by enabling control flow ops in the felxible backend when used by Qiskit.