### PR TITLE
Fix compatibility with pytest 8.4.0

### DIFF
--- a/benchpress/conftest.py
+++ b/benchpress/conftest.py
@@ -14,6 +14,7 @@ import time
 import numpy
 import scipy
 import pytest
+import packaging
 
 
 def pytest_benchmark_update_json(config, benchmarks, output_json):
@@ -24,7 +25,8 @@ def pytest_benchmark_update_json(config, benchmarks, output_json):
     # is recorded at. There does not seem to be a public api for it on
     # the terminal reporter so this lets us support both 8.4.0 or older
     # versions
-    if tuple(int(x) for x in pytest.__version__.split(".")) >= (8, 4, 0):
+    pytest_version = packaging.version.parse(pytest.__version__)
+    if pytest_version.release >= (8, 4, 0):
         output_json["total_duration"] = time.time() - reporter._session_start.time
     else:
         output_json["total_duration"] = time.time() - reporter._sessionstarttime

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-memray
 wrapt_timeout_decorator
+packaging>=20


### PR DESCRIPTION
This commit updates the benchpress JSON generation to be compatible with 8.4.0. 8.4.0 changed the internal API for storing the session start time which broke how benchpress was querying the data. The session start time doesn't seem to be queriable (at least for my brief 3 min search) from a public api of the terminal reporter so this opts to just update the internal usage based on the installed pytest version.